### PR TITLE
Alert fixes

### DIFF
--- a/alerts/keys-api-outdated-keys.rule.yml
+++ b/alerts/keys-api-outdated-keys.rule.yml
@@ -2,7 +2,8 @@ groups:
   - name: Keys API. Keys
     rules:
       - alert: KeysApiOutdatedKeys
-        expr: time() - lido_keys_api_last_update_timestamp{} >= 5 * 60
+        expr: time()  - lido_keys_api_last_update_timestamp{} >= 5 * 60
+        for: 3m
         labels:
           severity: critical
           service: keys_api

--- a/alerts/keys-api-outdated-keys.rule.yml
+++ b/alerts/keys-api-outdated-keys.rule.yml
@@ -4,7 +4,7 @@ groups:
       - alert: KeysApiOutdatedKeys
         expr: time() - lido_keys_api_last_update_timestamp{} >= 5 * 60
         labels:
-          severity: warning
+          severity: critical
           service: keys_api
           app_team: tooling
         annotations:

--- a/alerts/keys-api-outdated-keys.test.yml
+++ b/alerts/keys-api-outdated-keys.test.yml
@@ -14,7 +14,7 @@ tests:
         alertname: KeysApiOutdatedKeys
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: critical
               service: keys_api
               app_team: tooling
             exp_annotations:
@@ -24,7 +24,7 @@ tests:
         alertname: KeysApiOutdatedKeys
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: critical
               service: keys_api
               app_team: tooling
             exp_annotations:

--- a/alerts/keys-api-outdated-keys.test.yml
+++ b/alerts/keys-api-outdated-keys.test.yml
@@ -4,7 +4,7 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  # Outdated keys list. Outdated
+  # Outdated keys
   - interval: 5m
     input_series:
       - series: lido_keys_api_last_update_timestamp{}
@@ -31,11 +31,11 @@ tests:
               summary: Keys are outdated
               description: Keys were not updated for 8m 20s
 
-  #Outdated keys list. Up to date
+  # Actual keys
   - interval: 5m
     input_series:
       - series: lido_keys_api_last_update_timestamp{}
-        values: 0 300 600 601
+        values: 0 0 600 601
     alert_rule_test:
       - eval_time: 10m
         alertname: KeysApiOutdatedKeys
@@ -44,18 +44,22 @@ tests:
         alertname: KeysApiOutdatedKeys
         exp_alerts: []
 
-  # Outdated keys list. Initial start
-  - interval: 10m
+  # fire alert only if it active 3 minutes
+  - interval: 1m
     input_series:
       - series: lido_keys_api_last_update_timestamp{}
-        values: _ _ _ 1501
+        values: 0 0 0 0 0 0 0 0 0 0 200 0 0 481
     alert_rule_test:
-      - eval_time: 10m
+      - eval_time: 8m
         alertname: KeysApiOutdatedKeys
-        exp_alerts: []
-      - eval_time: 20m
-        alertname: KeysApiOutdatedKeys
-        exp_alerts: []
-      - eval_time: 30m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: keys_api
+              app_team: tooling
+            exp_annotations:
+              summary: Keys are outdated
+              description: Keys were not updated for 8m 0s
+      - eval_time: 13m
         alertname: KeysApiOutdatedKeys
         exp_alerts: []

--- a/alerts/keys-api-outdated-keys.test.yml
+++ b/alerts/keys-api-outdated-keys.test.yml
@@ -48,7 +48,7 @@ tests:
   - interval: 1m
     input_series:
       - series: lido_keys_api_last_update_timestamp{}
-        values: 0 0 0 0 0 0 0 0 0 0 200 0 0 481
+        values: 0x9 200 0 0 481
     alert_rule_test:
       - eval_time: 8m
         alertname: KeysApiOutdatedKeys

--- a/alerts/keys-api-outdated-validators.rule.yml
+++ b/alerts/keys-api-outdated-validators.rule.yml
@@ -2,11 +2,11 @@ groups:
   - name: Keys API. Validators
     rules:
       - alert: KeysApiOutdatedValidators
-        expr: time() - lido_keys_api_validators_registry_last_update_block_timestamp{} >=  60 * 30
+        expr: validators_registry_enabled{} == 1 AND (time() - lido_keys_api_validators_registry_last_update_block_timestamp{} >= 1800)
         labels:
-          severity: warning
+          severity: critical
           service: keys_api
           app_team: tooling
         annotations:
           summary: Validators are outdated
-          description: Validators were not updated for {{ $value | humanizeDuration }}
+          description: Validators were not updated for more than 30 minutes

--- a/alerts/keys-api-outdated-validators.test.yml
+++ b/alerts/keys-api-outdated-validators.test.yml
@@ -4,9 +4,22 @@ rule_files:
 evaluation_interval: 1m
 
 tests:
-  # Outdated validators list. Outdated
+  # Validators registry is disabled
   - interval: 15m
     input_series:
+      - series: validators_registry_enabled{}
+        values: 0 0 0
+      - series: lido_keys_api_validators_registry_last_update_block_timestamp{}
+        values: 0 0 0
+    alert_rule_test:
+      - eval_time: 30m
+        alertname: KeysApiOutdatedValidators
+        exp_alerts: []
+  # Outdated validators list
+  - interval: 15m
+    input_series:
+      - series: validators_registry_enabled{}
+        values: 1 1 1 1
       - series: lido_keys_api_validators_registry_last_update_block_timestamp{}
         values: 0 0 0 900
     alert_rule_test:
@@ -14,41 +27,30 @@ tests:
         alertname: KeysApiOutdatedValidators
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: critical
               service: keys_api
               app_team: tooling
             exp_annotations:
               summary: Validators are outdated
-              description: Validators were not updated for 30m 0s
+              description: Validators were not updated for more than 30 minutes
       - eval_time: 45m
         alertname: KeysApiOutdatedValidators
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: critical
               service: keys_api
               app_team: tooling
             exp_annotations:
               summary: Validators are outdated
-              description: Validators were not updated for 30m 0s
+              description: Validators were not updated for more than 30 minutes
 
-  # Outdated validators list. Up to date
+  # Actual validators list
   - interval: 15m
     input_series:
+      - series: validators_registry_enabled{}
+        values: 1 1 1 1
       - series: lido_keys_api_validators_registry_last_update_block_timestamp{}
         values: 0 0 1 901
-    alert_rule_test:
-      - eval_time: 30m
-        alertname: KeysApiOutdatedValidators
-        exp_alerts: []
-      - eval_time: 45m
-        alertname: KeysApiOutdatedValidators
-        exp_alerts: []
-
-  # Outdated validators list. Initial start
-  - interval: 15m
-    input_series:
-      - series: lido_keys_api_validators_registry_last_update_block_timestamp{}
-        values: _ _ _ 901
     alert_rule_test:
       - eval_time: 30m
         alertname: KeysApiOutdatedValidators

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -95,4 +95,10 @@ export class PrometheusService {
     name: 'validators_registry_last_slot',
     help: 'Slot for which the last ValidatorsRegistry update was made.',
   });
+
+  public validatorsEnabled = this.getOrCreateMetric('Gauge', {
+    prefix: true,
+    name: 'validators_registry_enabled',
+    help: 'Validators registry is enabled',
+  });
 }

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -3,6 +3,7 @@ import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
 import { ValidatorsUpdateService } from './validators-update/validators-update.service';
 import { KeysUpdateService } from './keys-update';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { PrometheusService } from 'common/prometheus';
 
 @Injectable()
 export class JobsService implements OnModuleInit, OnModuleDestroy {
@@ -11,6 +12,7 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     protected readonly keysUpdateService: KeysUpdateService,
     protected readonly validatorUpdateService: ValidatorsUpdateService,
     protected readonly schedulerRegistry: SchedulerRegistry,
+    protected readonly prometheusService: PrometheusService,
   ) {}
 
   public async onModuleInit(): Promise<void> {
@@ -37,9 +39,11 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
     await this.keysUpdateService.initialize();
 
     if (this.validatorUpdateService.isDisabledRegistry()) {
+      this.prometheusService.validatorsEnabled.set(0);
       this.logger.log('Job for updating validators is disabled');
       return;
     }
+    this.prometheusService.validatorsEnabled.set(1);
 
     await this.validatorUpdateService.initialize();
   }


### PR DESCRIPTION
  KeysApiOutdatedKeys alert  is always fired before restart of KAPI (example https://lidoteam.app.eu.opsgenie.com/alert/detail/a3666ef9-96fc-493c-8cbf-e412d9015604-1682414424398/details)
  Description Keys were not updated for 19474d 10h 55m 53s. It could happen if lido_keys_api_last_update_timestamp{} = 0 - it is 1970 year
  
  Important configurations for alert:
      group_interval: 5m 
      scrape_interval : 10s - how often scrap metrics
      evaluation_interval: 1m - how often evaluate alert rules
      repeat_interval: 4h
      
We can set 'for: 3m' ( or 2m) - It will help not to fire alert if this condition not true during all period. But it means that we will get alert after 3m (for) + 5m(from alert cond)  keys outdate. (And also we should keep in mind that we have  evaluation_interval > scrape_interval, so it can be + 1m to 3m (for) + 5m(from alert cond)). Maybe this for: 3m we will fix in future
     So now we will have ( 5m(from alert condition) + 1m (evaluation_interval) + 3m (for) ) + group_interval (as prometheus will wait the same alerts before sending notification) . Is it not too long before firing alert ~ 14m?
     
 For Validators alert didnt have this problem : time() - lido_keys_api_validators_registry_last_update_block_timestamp{} >= 1800 (30m on updating validators). disabled if validators collection disabled in service instance
 
 
 Also for Keys update we can featch last block and timestamp from db and set metric in the beginning 
 It also can prevent firing of alert during restart. And prevent incorrect info about last update
     
     
     
     
    
    
     
    
 
