### PR TITLE
fix: default app name

### DIFF
--- a/src/app/app.constants.ts
+++ b/src/app/app.constants.ts
@@ -1,3 +1,3 @@
 export const APP_VERSION = process.env.npm_package_version ?? 'unversioned';
-export const APP_NAME = process.env.npm_package_name ?? 'unnamed';
+export const APP_NAME = process.env.npm_package_name ?? 'lido-keys-api';
 export const APP_DESCRIPTION = process.env.npm_package_description ?? 'lido-keys-api';


### PR DESCRIPTION
Fix the default application name to correspond to the repository name.

@infloop asked me about the same thing in the `node-operators-widget-backend-ts` repository. I decided that the same change is reasonable for Keys API too.
https://github.com/lidofinance/node-operators-widget-backend-ts/pull/25#discussion_r1344634340
