### PR TITLE
chore: add more info about installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ You can familiarize yourself with the REST API by accessing it [here](rest-api.m
 
 ## Installation
 
-`$ yarn install`
+1. `$ yarn install`
+2. `$ yarn typechain`
 
 ## Running
 


### PR DESCRIPTION
Add one missing step to the "Installation" section of README.md about generating typechain.