### PR TITLE
fix: remove duplicated `PORT` var from sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -29,7 +29,6 @@ CHRONIX_PROVIDER_MAINNET_URL=https://mainnet.infura.io/v3/XXX,https://eth-mainne
 # for testnet 5
 CHAIN_ID=1
 
-PORT=3000
 DB_NAME=node_operator_keys_service_db
 DB_PORT=5432
 DB_HOST=localhost


### PR DESCRIPTION
Previously the `PORT` variable was listed twice in `sample.env`. Now this is fixed.