### PR TITLE
refactor!: environment variables validation

### DIFF
--- a/src/common/config/interfaces/environment.interface.ts
+++ b/src/common/config/interfaces/environment.interface.ts
@@ -17,3 +17,9 @@ export enum LogFormat {
   json = 'json',
   simple = 'simple',
 }
+
+export enum Network {
+  Mainnet = 1,
+  Goerli = 5,
+  Holesky = 17000,
+}


### PR DESCRIPTION
Refactor environment variable validation rules. Apply consistent patterns to env validation.

The main motivation for this change was as follows:

1. Make env validation more strict and consistent. Stick to the same validation patterns in different projects.

2. Provide consistent fallback options for optional variables.

Here are the main changes:  

1. Previously if a user set an empty string as the variable name in the .env file like this:
```
VARIABLE_NAME=
```
not all variable initializers assigned a correct default value to the variable in this case. Now it is fixed.
For the purpose of this improvement, now all optional variable initializers always have the `@Transform` decorator that provides a default value for the variable.
Also for this purpose, the `toBoolean` function has been refactored to be more similar to the `toNumber` function.

2. Make validation of boolean variables more strict.
CAUTION: This might be a breaking change for users who use values like "yes" to initialize boolean variables.

3. Implement the new `toArrayOfUrls()` function to provide a reasonable default value for variables that should have a list of URLs in their values.
This function also fixes a bug with default values for such variables. Previously, if a user set an empty string as a value of such variables, the validation worked incorrectly.

4. Now we validate that values in `PROVIDERS_URLS` and `CL_API_URLS` are indeed URLs.

5. The `CHAIN_ID` variable now supports only a pre-defined list of testnet IDs. Add the appropriate `Network` enum for this purpose.
CAUTION: Currently the Keys API doesn't officially support testnets other than Goerli, Holesky, and Mainnet. But this might be a breaking change if some users use Keys API for other testnets.

6. More strict validation for the `PORT` and `DB_PORT` values.
CAUTION: This might be a breaking change.

7. Add the `@IsNotEmpty` decorator to the required variables.

8. Fix confusing validation rules for the `DB_PASSWORD` variable. Add default value.