### PR TITLE
fix: add missing `middleware` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@lido-nestjs/execution": "^1.11.0",
     "@lido-nestjs/fetch": "^1.4.0",
     "@lido-nestjs/logger": "^1.3.2",
+    "@lido-nestjs/middleware": "^1.2.0",
     "@lido-nestjs/validators-registry": "^1.3.0",
     "@mikro-orm/cli": "^5.5.3",
     "@mikro-orm/core": "^5.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1319,7 +1319,7 @@
     traverse "^0.6.7"
     winston "^3.4.0"
 
-"@lido-nestjs/middleware@1.2.0":
+"@lido-nestjs/middleware@1.2.0", "@lido-nestjs/middleware@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@lido-nestjs/middleware/-/middleware-1.2.0.tgz#0e64b69149ef1f7e4594896fd08d6e0bd9ef5382"
   integrity sha512-0rkXWKXEKJPRbq1W6cN+yelhc+CruqhUqmdkNKwl4vTk631fpG9yfSfxxQFDAs3LhsTORqqgKUBpdK+epRYjIQ==


### PR DESCRIPTION
Add the missing `@lido-nextjs/middleware` package to the "dependencies" section of the `package.json` file.

The `MiddlewareService` symbol from this package is used in the `src/common/consensus-provider/consensus-fetch.service.ts` file but was not explicitly listed in dependencies. Now it is fixed.