### PR TITLE
fix: required field marks in Swagger annotations

### DIFF
--- a/src/app/simple-dvt-deploy.e2e-chain.ts
+++ b/src/app/simple-dvt-deploy.e2e-chain.ts
@@ -61,7 +61,7 @@ describe('Simple DVT deploy', () => {
     session = await sdk.env.hardhat({
       fork: forkUrl,
       chainId: 1,
-      forkBlockNumber: 19282216
+      forkBlockNumber: 19282216,
     });
 
     moduleRef = await Test.createTestingModule({ imports: [AppModule] })

--- a/src/http/common/entities/cl-meta.ts
+++ b/src/http/common/entities/cl-meta.ts
@@ -4,6 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class CLMeta {
   @ApiProperty({
     type: () => CLBlockSnapshot,
+    required: true,
     description: 'Consensus layer block information',
   })
   clBlockSnapshot!: CLBlockSnapshot;

--- a/src/http/common/entities/el-meta.ts
+++ b/src/http/common/entities/el-meta.ts
@@ -4,6 +4,7 @@ import { ELBlockSnapshot } from './el-block-snapshot';
 export class ELMeta {
   @ApiProperty({
     type: () => ELBlockSnapshot,
+    required: true,
     description: 'Execution layer block information',
   })
   elBlockSnapshot!: ELBlockSnapshot;

--- a/src/http/common/entities/operator.ts
+++ b/src/http/common/entities/operator.ts
@@ -17,31 +17,51 @@ export class Operator implements Omit<RegistryOperator, 'finalizedUsedSigningKey
   }
 
   @ApiProperty({
+    required: true,
     description: 'Index of Operator',
   })
   index: number;
 
   @ApiProperty({
+    required: true,
     description: 'This value shows if node operator active',
   })
   active: boolean;
 
-  @ApiProperty({ description: 'Operator name' })
+  @ApiProperty({
+    required: true,
+    description: 'Operator name',
+  })
   name: string;
 
-  @ApiProperty({ description: 'Ethereum 1 address which receives stETH rewards for this operator' })
+  @ApiProperty({
+    required: true,
+    description: 'Ethereum 1 address which receives stETH rewards for this operator',
+  })
   rewardAddress: string;
 
-  @ApiProperty({ description: 'The number of keys vetted by the DAO and that can be used for the deposit' })
+  @ApiProperty({
+    required: true,
+    description: 'The number of keys vetted by the DAO and that can be used for the deposit',
+  })
   stakingLimit: number;
 
-  @ApiProperty({ description: 'Amount of stopped validators' })
+  @ApiProperty({
+    required: true,
+    description: 'Amount of stopped validators',
+  })
   stoppedValidators: number;
 
-  @ApiProperty({ description: 'Total signing keys amount' })
+  @ApiProperty({
+    required: true,
+    description: 'Total signing keys amount',
+  })
   totalSigningKeys: number;
 
-  @ApiProperty({ description: 'Amount of used signing keys' })
+  @ApiProperty({
+    required: true,
+    description: 'Amount of used signing keys',
+  })
   usedSigningKeys: number;
 
   @ApiProperty({

--- a/src/http/common/entities/sr-module.ts
+++ b/src/http/common/entities/sr-module.ts
@@ -21,69 +21,81 @@ export class StakingModuleResponse implements Omit<SrModuleEntity, 'id' | 'modul
   }
 
   @ApiProperty({
+    required: true,
     description:
-      "Counter that MUST change value if keys were added, removed, node operator was activated/deactivated,  a node operator's ready to deposit keys count is changed",
+      "Counter that MUST change value if keys were added, removed, node operator was activated/deactivated, a node operator's ready to deposit keys count is changed",
   })
   nonce: number;
 
   @ApiProperty({
+    required: true,
     description: 'Type of module',
   })
   type: string; //STAKING_MODULE_TYPE;
 
   @ApiProperty({
+    required: true,
     description: 'Unique id of the module',
   })
   id: number;
 
   @ApiProperty({
+    required: true,
     description: 'Address of module',
   })
   stakingModuleAddress: string;
 
   @ApiProperty({
+    required: true,
     description: 'Reward fee of the module',
   })
   moduleFee: number;
 
   @ApiProperty({
+    required: true,
     description: 'Treasury fee',
   })
   treasuryFee: number;
 
   @ApiProperty({
+    required: true,
     description: 'Target percent of total keys in protocol, in BP',
   })
   targetShare: number;
 
   @ApiProperty({
+    required: true,
     description:
       'Module status if module can not accept the deposits or can participate in further reward distribution',
   })
   status: number;
 
   @ApiProperty({
+    required: true,
     description: 'Name of module',
   })
   name: string;
 
   @ApiProperty({
+    required: true,
     description: 'block.timestamp of the last deposit of the module',
   })
   lastDepositAt: number;
 
   @ApiProperty({
+    required: true,
     description: 'block.number of the last deposit of the module',
-    nullable: true,
   })
   lastDepositBlock: number;
 
   @ApiProperty({
+    required: true,
     description: 'Exited validators count',
   })
   exitedValidatorsCount: number;
 
   @ApiProperty({
+    required: true,
     description: 'Module activation status',
   })
   active: boolean;

--- a/src/http/keys/entities/index.ts
+++ b/src/http/keys/entities/index.ts
@@ -1,1 +1,1 @@
-export * from './response';
+export * from './keys.response';

--- a/src/http/keys/entities/keys.response.ts
+++ b/src/http/keys/entities/keys.response.ts
@@ -4,13 +4,14 @@ import { ELMeta, Key } from '../../common/entities';
 export class KeyListResponse {
   @ApiProperty({
     type: () => [Key],
+    required: true,
     description: 'List of keys for all modules',
   })
   data!: Key[];
 
   @ApiProperty({
     type: () => ELMeta,
-    nullable: true,
+    required: true,
     description: 'Meta',
   })
   meta!: ELMeta;

--- a/src/http/keys/keys.controller.ts
+++ b/src/http/keys/keys.controller.ts
@@ -114,7 +114,7 @@ export class KeysController {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    description: 'Staking Router module keys.',
+    description: 'Staking Router module keys',
     type: KeyListResponse,
   })
   @ApiOperation({ summary: 'Get list of found keys in DB from pubkey list' })

--- a/src/http/sr-modules-keys/entities/grouped-by-module-keys.response.ts
+++ b/src/http/sr-modules-keys/entities/grouped-by-module-keys.response.ts
@@ -3,28 +3,32 @@ import { Key, StakingModuleResponse, ELMeta } from '../../common/entities/';
 
 export class KeyListWithModule {
   @ApiProperty({
-    description: 'Keys of staking router module',
     type: () => [Key],
+    required: true,
+    description: 'Keys of staking router module',
   })
   keys!: Key[];
 
   @ApiProperty({
-    description: 'Detailed Staking Router information',
     type: () => StakingModuleResponse,
+    required: true,
+    description: 'Detailed Staking Router information',
   })
   module!: StakingModuleResponse;
 }
 
 export class GroupedByModuleKeyListResponse {
   @ApiProperty({
-    description: 'Keys for all modules grouped by staking router module',
     type: () => [KeyListWithModule],
+    required: true,
+    description: 'Keys for all modules grouped by staking router module',
   })
   data!: KeyListWithModule[];
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }

--- a/src/http/sr-modules-keys/entities/sr-module-keys.response.ts
+++ b/src/http/sr-modules-keys/entities/sr-module-keys.response.ts
@@ -4,28 +4,31 @@ import { StakingModuleResponse, Key, ELMeta } from '../../common/entities/';
 export class SRKeyListWithModule {
   @ApiProperty({
     type: () => [Key],
+    required: true,
     description: 'Keys of staking router module',
   })
   keys!: Key[];
 
   @ApiProperty({
-    description: 'Detailed Staking Router information',
     type: () => StakingModuleResponse,
+    required: true,
+    description: 'Detailed Staking Router information',
   })
   module!: StakingModuleResponse;
 }
 
 export class SRModuleKeyListResponse {
   @ApiProperty({
-    description: 'Staking router module keys.',
-    nullable: true,
     type: () => SRKeyListWithModule,
+    required: true,
+    description: 'Staking router module keys',
   })
   data!: SRKeyListWithModule;
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }

--- a/src/http/sr-modules-keys/sr-modules-keys.controller.ts
+++ b/src/http/sr-modules-keys/sr-modules-keys.controller.ts
@@ -36,7 +36,7 @@ export class SRModulesKeysController {
   ) {}
 
   @Version('1')
-  @ApiOperation({ summary: 'Get keys for all modules grouped by staking router module.' })
+  @ApiOperation({ summary: 'Get keys for all modules grouped by staking router module' })
   @ApiResponse({
     status: 200,
     description:
@@ -54,7 +54,7 @@ export class SRModulesKeysController {
   }
 
   @Version('1')
-  @ApiOperation({ summary: 'Staking router module keys.' })
+  @ApiOperation({ summary: 'Staking router module keys' })
   @ApiResponse({
     status: 200,
     description: 'List of all modules supported in API',
@@ -73,7 +73,7 @@ export class SRModulesKeysController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   @Get(':module_id/keys')
   async getModuleKeys(
@@ -118,10 +118,10 @@ export class SRModulesKeysController {
   @Version('1')
   @Post(':module_id/keys/find')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Get list of found staking router module keys in db from pubkey list.' })
+  @ApiOperation({ summary: 'Get list of found staking router module keys in db from pubkey list' })
   @ApiResponse({
     status: 200,
-    description: 'Staking Router module keys.',
+    description: 'Staking Router module keys',
     type: SRModuleKeyListResponse,
   })
   @ApiResponse({
@@ -137,7 +137,7 @@ export class SRModulesKeysController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   getModuleKeysByPubkeys(@Param('module_id', ModuleIdPipe) module_id: string | number, @Body() keys: KeysFindBody) {
     return this.srModulesKeysService.getModuleKeysByPubKeys(module_id, keys.pubkeys);

--- a/src/http/sr-modules-operators-keys/entities/sr-module-operators-keys.response.ts
+++ b/src/http/sr-modules-operators-keys/entities/sr-module-operators-keys.response.ts
@@ -4,34 +4,38 @@ import { Key, Operator, StakingModuleResponse, ELMeta } from '../../common/entit
 export class SROperatorsKeysModule {
   @ApiProperty({
     type: () => [Operator],
+    required: true,
     description: 'Operators of staking router module',
   })
   operators!: Operator[];
 
   @ApiProperty({
     type: () => [Key],
+    required: true,
     description: 'Keys of staking router module',
   })
   keys!: Key[];
 
   @ApiProperty({
-    description: 'Detailed Staking Router information',
     type: () => StakingModuleResponse,
+    required: true,
+    description: 'Detailed Staking Router information',
   })
   module!: StakingModuleResponse;
 }
 
 export class SRModuleOperatorsKeysResponse {
   @ApiProperty({
-    description: 'Staking router module keys.',
-    nullable: true,
     type: () => SROperatorsKeysModule,
+    required: true,
+    description: 'Staking router module keys',
   })
   data!: SROperatorsKeysModule;
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }
@@ -39,25 +43,29 @@ export class SRModuleOperatorsKeysResponse {
 export class SRModulesOperatorsKeysStreamResponse {
   @ApiProperty({
     type: () => Operator,
+    nullable: true,
     description: 'Operator of staking router module',
   })
   operator!: Operator | null;
 
   @ApiProperty({
     type: () => Key,
+    nullable: true,
     description: 'Key of staking router module',
   })
   key!: Key | null;
 
   @ApiProperty({
     type: () => StakingModuleResponse,
+    nullable: true,
     description: 'Staking Router module',
   })
   stakingModule!: StakingModuleResponse | null;
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    nullable: true,
+    description: 'Meta',
   })
   meta!: ELMeta | null;
 }

--- a/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
+++ b/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
@@ -32,7 +32,7 @@ export class SRModulesOperatorsKeysController {
   ) {}
 
   @Version('1')
-  @ApiOperation({ summary: 'Staking router module operators.' })
+  @ApiOperation({ summary: 'Staking router module operators' })
   @ApiResponse({
     status: 200,
     description: 'List of all SR module operators',
@@ -51,7 +51,7 @@ export class SRModulesOperatorsKeysController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   @Get(':module_id/operators/keys')
   async getOperatorsKeys(

--- a/src/http/sr-modules-operators/entities/grouped-by-module-operators.response.ts
+++ b/src/http/sr-modules-operators/entities/grouped-by-module-operators.response.ts
@@ -4,14 +4,16 @@ import { OperatorListAndSRModule } from './sr-module-operators.response';
 
 export class GroupedByModuleOperatorListResponse {
   @ApiProperty({
-    description: 'Operators for all modules grouped by staking router module',
     type: () => [OperatorListAndSRModule],
+    required: true,
+    description: 'Operators for all modules grouped by staking router module',
   })
   data!: OperatorListAndSRModule[];
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }

--- a/src/http/sr-modules-operators/entities/sr-module-operator.response.ts
+++ b/src/http/sr-modules-operators/entities/sr-module-operator.response.ts
@@ -3,7 +3,7 @@ import { StakingModuleResponse, ELMeta, Operator } from '../../common/entities/'
 
 export class OperatorAndSRModule {
   @ApiProperty({
-    type: () => [Operator],
+    type: () => Operator,
     required: true,
     description: 'Operator of staking router module',
   })

--- a/src/http/sr-modules-operators/entities/sr-module-operator.response.ts
+++ b/src/http/sr-modules-operators/entities/sr-module-operator.response.ts
@@ -4,28 +4,31 @@ import { StakingModuleResponse, ELMeta, Operator } from '../../common/entities/'
 export class OperatorAndSRModule {
   @ApiProperty({
     type: () => [Operator],
+    required: true,
     description: 'Operator of staking router module',
   })
   operator!: Operator;
 
   @ApiProperty({
-    description: 'Detailed Staking Router information',
     type: () => StakingModuleResponse,
+    required: true,
+    description: 'Detailed Staking Router information',
   })
   module!: StakingModuleResponse;
 }
 
 export class SRModuleOperatorResponse {
   @ApiProperty({
-    description: 'Staking router module keys.',
-    nullable: true,
     type: () => OperatorAndSRModule,
+    required: true,
+    description: 'Staking router module keys',
   })
   data!: OperatorAndSRModule;
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }

--- a/src/http/sr-modules-operators/entities/sr-module-operators.response.ts
+++ b/src/http/sr-modules-operators/entities/sr-module-operators.response.ts
@@ -4,28 +4,31 @@ import { StakingModuleResponse, ELMeta, Operator } from '../../common/entities/'
 export class OperatorListAndSRModule {
   @ApiProperty({
     type: () => [Operator],
+    required: true,
     description: 'Operators of staking router module',
   })
   operators!: Operator[];
 
   @ApiProperty({
-    description: 'Detailed Staking Router information',
     type: () => StakingModuleResponse,
+    required: true,
+    description: 'Detailed Staking Router information',
   })
   module!: StakingModuleResponse;
 }
 
 export class SRModuleOperatorListResponse {
   @ApiProperty({
-    description: 'Staking router module operators.',
-    nullable: true,
     type: () => OperatorListAndSRModule,
+    required: true,
+    description: 'Staking router module operators',
   })
   data!: OperatorListAndSRModule;
 
   @ApiProperty({
-    nullable: true,
     type: () => ELMeta,
+    required: true,
+    description: 'Meta',
   })
   meta!: ELMeta;
 }

--- a/src/http/sr-modules-operators/sr-modules-operators.controller.ts
+++ b/src/http/sr-modules-operators/sr-modules-operators.controller.ts
@@ -16,10 +16,10 @@ export class SRModulesOperatorsController {
   constructor(protected readonly srModulesOperators: SRModulesOperatorsService) {}
 
   @Version('1')
-  @ApiOperation({ summary: 'Get operators for all modules grouped by staking router module.' })
+  @ApiOperation({ summary: 'Get operators for all modules grouped by staking router module' })
   @ApiResponse({
     status: 200,
-    description: 'Operators for all modules grouped by staking router module.',
+    description: 'Operators for all modules grouped by staking router module',
     type: () => GroupedByModuleOperatorListResponse,
   })
   @ApiResponse({
@@ -33,7 +33,7 @@ export class SRModulesOperatorsController {
   }
 
   @Version('1')
-  @ApiOperation({ summary: 'Staking router module operators.' })
+  @ApiOperation({ summary: 'Staking router module operators' })
   @ApiResponse({
     status: 200,
     description: 'List of all SR module operators',
@@ -52,7 +52,7 @@ export class SRModulesOperatorsController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   @Get('modules/:module_id/operators')
   getModuleOperators(@Param('module_id', ModuleIdPipe) module_id: string | number) {
@@ -60,7 +60,7 @@ export class SRModulesOperatorsController {
   }
 
   @Version('1')
-  @ApiOperation({ summary: 'Staking router module operator.' })
+  @ApiOperation({ summary: 'Staking router module operator' })
   @ApiResponse({
     status: 200,
     description: 'SR module operator',
@@ -79,7 +79,7 @@ export class SRModulesOperatorsController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   @Get('modules/:module_id/operators/:operator_id')
   getModuleOperator(@Param('module_id', ModuleIdPipe) module_id: string | number, @Param() operator: OperatorId) {

--- a/src/http/sr-modules-validators/entities/exit-validator.ts
+++ b/src/http/sr-modules-validators/entities/exit-validator.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class ExitValidator {
   @ApiProperty({
     required: true,
-    description: 'Index of validator.',
+    description: 'Index of validator',
   })
   validatorIndex!: number;
 

--- a/src/http/sr-modules-validators/entities/exit-validators.response.ts
+++ b/src/http/sr-modules-validators/entities/exit-validators.response.ts
@@ -4,16 +4,16 @@ import { ExitValidator } from './exit-validator';
 
 export class ExitValidatorListResponse {
   @ApiProperty({
+    type: () => [ExitValidator],
     required: true,
     description: 'N oldest validators for current epoch when voluntary exit can be processed',
-    type: () => [ExitValidator],
   })
   data!: ExitValidator[];
 
   @ApiProperty({
-    nullable: true,
-    description: 'Meta for voluntary exit endpoints',
     type: () => CLMeta,
+    required: true,
+    description: 'Meta for voluntary exit endpoints',
   })
   meta!: CLMeta;
 }

--- a/src/http/sr-modules-validators/entities/exits-presign-message.reponse.ts
+++ b/src/http/sr-modules-validators/entities/exits-presign-message.reponse.ts
@@ -4,17 +4,16 @@ import { ExitPresignMessage } from './exits-presign-message';
 
 export class ExitPresignMessageListResponse {
   @ApiProperty({
+    type: () => [ExitPresignMessage],
     required: true,
     description: 'Voluntary exit message list',
-    type: () => [ExitPresignMessage],
   })
   data!: ExitPresignMessage[];
 
   @ApiProperty({
+    type: () => CLMeta,
     required: true,
     description: 'Meta for voluntary exit endpoints',
-    nullable: true,
-    type: () => CLMeta,
   })
   meta!: CLMeta;
 }

--- a/src/http/sr-modules-validators/entities/exits-presign-message.ts
+++ b/src/http/sr-modules-validators/entities/exits-presign-message.ts
@@ -3,13 +3,13 @@ import { ApiProperty } from '@nestjs/swagger';
 export class ExitPresignMessage {
   @ApiProperty({
     required: true,
-    description: 'Index of validator.',
+    description: 'Index of validator',
   })
   validator_index!: string;
 
   @ApiProperty({
     required: true,
-    description: 'Finalized epoch.',
+    description: 'Finalized epoch',
   })
   epoch!: string;
 }

--- a/src/http/sr-modules-validators/sr-modules-validators.controller.ts
+++ b/src/http/sr-modules-validators/sr-modules-validators.controller.ts
@@ -33,7 +33,7 @@ export class SRModulesValidatorsController {
   @ApiOperation({ summary: 'Get list of N oldest lido validators' })
   @ApiResponse({
     status: 200,
-    description: 'N oldest lido validators for operator.',
+    description: 'N oldest lido validators for operator',
     type: ExitValidatorListResponse,
   })
   @ApiResponse({
@@ -54,7 +54,7 @@ export class SRModulesValidatorsController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   getOldestValidators(
     @Param('module_id', ModuleIdPipe) module_id: string | number,

--- a/src/http/sr-modules/entities/sr-modules.response.ts
+++ b/src/http/sr-modules/entities/sr-modules.response.ts
@@ -4,12 +4,14 @@ import { StakingModuleResponse, ELBlockSnapshot } from '../../common/entities/';
 export class SRModuleListResponse {
   @ApiProperty({
     type: () => [StakingModuleResponse],
+    required: true,
     description: 'List of staking router modules with detailed information',
   })
   data!: StakingModuleResponse[];
 
   @ApiProperty({
     type: () => ELBlockSnapshot,
+    required: true,
     description: 'Execution layer block information',
   })
   elBlockSnapshot!: ELBlockSnapshot;
@@ -18,12 +20,14 @@ export class SRModuleListResponse {
 export class SRModuleResponse {
   @ApiProperty({
     type: () => StakingModuleResponse,
+    required: true,
     description: 'Detailed staking router module information',
   })
   data!: StakingModuleResponse;
 
   @ApiProperty({
     type: () => ELBlockSnapshot,
+    required: true,
     description: 'Execution layer block information',
   })
   elBlockSnapshot!: ELBlockSnapshot;

--- a/src/http/sr-modules/sr-modules.controller.ts
+++ b/src/http/sr-modules/sr-modules.controller.ts
@@ -11,7 +11,7 @@ export class SRModulesController {
   constructor(protected readonly srModulesService: SRModulesService) {}
 
   @Version('1')
-  @ApiOperation({ summary: 'Get list of modules supported in API.' })
+  @ApiOperation({ summary: 'Get list of modules supported in API' })
   @ApiResponse({
     status: 200,
     description: 'List of all modules supported in API',
@@ -28,10 +28,10 @@ export class SRModulesController {
   }
 
   @Version('1')
-  @ApiOperation({ summary: 'Get detailed information about staking router module.' })
+  @ApiOperation({ summary: 'Get detailed information about staking router module' })
   @ApiResponse({
     status: 200,
-    description: 'Staking router module detailed information.',
+    description: 'Staking router module detailed information',
     type: SRModuleResponse,
   })
   @ApiResponse({
@@ -48,7 +48,7 @@ export class SRModulesController {
   @ApiParam({
     name: 'module_id',
     type: String,
-    description: 'Staking router module_id or contract address.',
+    description: 'Staking router module_id or contract address',
   })
   getModule(@Param('module_id', ModuleIdPipe) module_id: string | number) {
     return this.srModulesService.getModule(module_id);

--- a/src/http/status/entities/status.ts
+++ b/src/http/status/entities/status.ts
@@ -3,11 +3,13 @@ import { CLBlockSnapshot, ELBlockSnapshot } from 'http/common/entities';
 
 export class Status {
   @ApiProperty({
+    required: true,
     description: 'App version',
   })
   appVersion!: string;
 
   @ApiProperty({
+    required: true,
     description: 'Chain id',
   })
   chainId!: number;
@@ -21,6 +23,7 @@ export class Status {
 
   @ApiProperty({
     type: () => CLBlockSnapshot,
+    nullable: true,
     description: 'Consensus layer block information',
   })
   clBlockSnapshot!: CLBlockSnapshot | null;


### PR DESCRIPTION
In the previous version `required` and `nullable` annotations in `@ApiProperty` decorators were not accurate. Required fields frequently had `nullable` declarations and vice versa. It created difficulties for maintainers of external services that use Keys API under the hood because it was not possible to understand all the details of Keys API endpoint interfaces by just looking at the Swagger.

Now all annotations are brought into compliance with actual endpoint interfaces that Keys API uses internally.