### PR TITLE
fix: docker-compose DB config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: postgres:16-alpine
     restart: unless-stopped
     environment:
-      - POSTGRES_DB=${DB_NAME}
-      - POSTGRES_USER=${DB_USER}
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_NAME:-master}
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
     volumes:
       - ./.volumes/pgdata-${CHAIN_ID}/:/var/lib/postgresql/data
 
@@ -26,11 +26,11 @@ services:
       - PROVIDERS_URLS=${PROVIDERS_URLS}
       - CL_API_URLS=${CL_API_URLS}
       - CHAIN_ID=${CHAIN_ID}
-      - DB_NAME=${DB_NAME}
+      - DB_NAME=${DB_NAME:-master}
       - DB_PORT=5432
       - DB_HOST=db
-      - DB_USER=${DB_USER}
-      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_USER=postgres
+      - DB_PASSWORD=postgres
       - JOB_INTERVAL_REGISTRY=${JOB_INTERVAL_REGISTRY}
       - VALIDATOR_REGISTRY_ENABLE=${VALIDATOR_REGISTRY_ENABLE}
       - JOB_INTERVAL_VALIDATORS_REGISTRY=${JOB_INTERVAL_VALIDATORS_REGISTRY}


### PR DESCRIPTION
Setting custom values for Postgres user credentials did not work if the application running inside the container because by default the Postgres container creates only a default user with default credentials. Previously these custom credentials specified in the env variables were passed to the Postgres image and it led to an error, because this user didn't exist in the default configuration, so, containers crashed in this case.

Now if the app runs in containers, user credentials specified in the env variables are ignored and the default user credentials are used.

We already have similar adjustments in other reops and folks like the idea
https://github.com/lidofinance/node-operators-widget-backend-ts/pull/80
https://github.com/lidofinance/ethereum-validators-monitoring/pull/242