### PR TITLE
fix: start:prod script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node --max-old-space-size=4096 dist/main",
+    "start:prod": "test -f dist/main.js && node --max-old-space-size=4096 dist/main || node --max-old-space-size=4096 dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
The `start:prod` script in `package.json` worked incorrectly when the app was run locally without a container. Now it is fixed and the `start:prod` script is working fine when the app is running both locally and in a container.

In the commit `f4baaf5985962409b1667cca452eb85b03c96961` from 12.09.23 the `benchmarks` folder was included in the output directory. This changed the directory structure in the `dist` folder. Before 12.09 the application build was situated directly in the `dist` folder (so, the `main.js` file was inside the `dist` directory). After that commit, the `dist` folder contains two subfolders: `src` and `benchmarks` and the application build is inside the nested `src` folder. When the app is run locally, there is no `main.js` file inside the `dist` folder, so, the `start:prod` script from `package.json` fails.

This didn't break running application inside the container, because the Dockerfile copies only the `src` folder to the container and doesn't copy the `benchmark` folder. So, when the `yarn build` script prepares the application build, the folder structure inside the `dist` directory remains flat.

The new `start:prod` script checks if the `main.js` file is directly in the `dist` folder (this is the case when the app is run in a container). If yes, it uses this file to run the app. If now (that means that the app is run locally), the script gets the `main.js` file from the nested `src` folder.