### PR TITLE
fix: migrate tests from goerli to holesky

### DIFF
--- a/src/common/registry/test/fetch/key-batch.fetch.e2e-spec.ts
+++ b/src/common/registry/test/fetch/key-batch.fetch.e2e-spec.ts
@@ -27,7 +27,7 @@ describe('Fetch keys in batch', () => {
   });
 
   test('fetch one key', async () => {
-    const overrides = { blockTag: 10573030 };
+    const overrides = { blockTag: 1488022 };
     const keys = await fetchService.fetch(address, 17, 0, 3, overrides);
 
     expect(keys).toBeInstanceOf(Array);

--- a/src/common/registry/test/fetch/key.fetch.e2e-spec.ts
+++ b/src/common/registry/test/fetch/key.fetch.e2e-spec.ts
@@ -28,7 +28,7 @@ describe('Keys', () => {
   });
 
   test('fetch one key', async () => {
-    const key = await fetchService.fetchOne(address, 17, 0, { blockTag: 10573030 });
+    const key = await fetchService.fetchOne(address, 17, 0, { blockTag: 1488022 });
 
     expect(key).toBeInstanceOf(Object);
 
@@ -41,7 +41,7 @@ describe('Keys', () => {
 
   test('fetch operator keys', async () => {
     const keys = await fetchService.fetch(address, 17, 0, 3, {
-      blockTag: 10573030,
+      blockTag: 1488022,
     });
     expect(keys).toBeInstanceOf(Array);
     expect(keys.length).toBe(3);
@@ -49,7 +49,7 @@ describe('Keys', () => {
 
   test('fetch several keys', async () => {
     const keys = await fetchService.fetch(address, 17, 0, 2, {
-      blockTag: 10573030,
+      blockTag: 1488022,
     });
 
     expect(keys).toBeInstanceOf(Array);

--- a/src/common/registry/test/fetch/meta.fetch.e2e-spec.ts
+++ b/src/common/registry/test/fetch/meta.fetch.e2e-spec.ts
@@ -9,6 +9,7 @@ dotenv.config();
 
 describe('Operators', () => {
   const provider = getDefaultProvider(process.env.PROVIDERS_URLS);
+
   if (!process.env.CHAIN_ID) {
     console.error("CHAIN_ID wasn't provides");
     process.exit(1);

--- a/src/common/registry/test/fetch/operator.fetch.e2e-spec.ts
+++ b/src/common/registry/test/fetch/operator.fetch.e2e-spec.ts
@@ -52,7 +52,7 @@ describe('Operators', () => {
 
   test('fetch all operators', async () => {
     const operators = await fetchService.fetch(address, 0, -1, {
-      blockTag: 10573030,
+      blockTag: 1488022,
     });
 
     expect(operators).toBeInstanceOf(Array);
@@ -61,7 +61,7 @@ describe('Operators', () => {
 
   test('fetch multiply operators', async () => {
     const operators = await fetchService.fetch(address, 1, 3, {
-      blockTag: 10573030,
+      blockTag: 1488022,
     });
 
     expect(operators).toBeInstanceOf(Array);

--- a/src/common/registry/test/key-registry/connect.e2e-spec.ts
+++ b/src/common/registry/test/key-registry/connect.e2e-spec.ts
@@ -24,7 +24,7 @@ describe('Registry', () => {
   //   return { ...key, moduleAddress: address };
   // });
 
-  const blockHash = '0x42e6d3fe6df4bc4bdfda27595a015ac9fd5af65cf9bd9d8ad0f2ac802dd73749';
+  const blockHash = '0x947aa07f029fd9fed1af664339373077e61f54aff32d692e1f00139fcd4c5039';
 
   beforeEach(async () => {
     const imports = [
@@ -71,8 +71,8 @@ describe('Registry', () => {
     // });
 
     const operators = await registryService.getOperatorsFromStorage(address);
-    expect(operators).toHaveLength(89);
+    expect(operators.length).toEqual(36);
     const keys = await registryService.getOperatorsKeysFromStorage(address);
-    expect(keys).toHaveLength(57816);
+    expect(keys.length).toEqual(62381);
   }, 400_000);
 });

--- a/src/common/registry/test/validator-registry/connect.e2e-spec.ts
+++ b/src/common/registry/test/validator-registry/connect.e2e-spec.ts
@@ -33,7 +33,7 @@ describe('Registry', () => {
   //   return { ...key, moduleAddress: address };
   // });
 
-  const blockHash = '0x42e6d3fe6df4bc4bdfda27595a015ac9fd5af65cf9bd9d8ad0f2ac802dd73749';
+  const blockHash = '0x947aa07f029fd9fed1af664339373077e61f54aff32d692e1f00139fcd4c5039';
 
   beforeEach(async () => {
     const imports = [
@@ -81,8 +81,8 @@ describe('Registry', () => {
     // });
 
     const operators = await registryService.getOperatorsFromStorage(address);
-    expect(operators).toHaveLength(89);
+    expect(operators.length).toEqual(36);
     const keys = await registryService.getOperatorsKeysFromStorage(address);
-    expect(keys).toHaveLength(55131);
+    expect(keys.length).toEqual(28123);
   }, 400_000);
 });

--- a/src/common/registry/test/validator-registry/registry-update.e2e-spec.ts
+++ b/src/common/registry/test/validator-registry/registry-update.e2e-spec.ts
@@ -16,7 +16,7 @@ import { MikroORM } from '@mikro-orm/core';
 import { REGISTRY_CONTRACT_ADDRESSES } from '@lido-nestjs/contracts';
 import { DatabaseE2ETestingModule } from 'app';
 
-const blockHash = '0x4ef0f15a8a04a97f60a9f76ba83d27bcf98dac9635685cd05fe1d78bd6e93418';
+const blockHash = '0x947aa07f029fd9fed1af664339373077e61f54aff32d692e1f00139fcd4c5039';
 
 describe('Validator registry', () => {
   const provider = new JsonRpcBatchProvider(process.env.PROVIDERS_URLS);


### PR DESCRIPTION
Because of sunset of goerli tests it is better to move tests on holesky.
Need to change values of this variables on ci:
  ```
 env:
          PROVIDERS_URLS: ${{ secrets.PROVIDERS_URLS }}
          CHAIN_ID: ${{ secrets.CHAIN_ID }}
 ```