### PR TITLE
feat: sanity checker for network config

### DIFF
--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, LoggerService, OnModuleInit } from '@nestjs/common';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { ExecutionProviderService } from '../common/execution-provider';
-import { ConsensusProviderService } from '../common/consensus-provider';
 import { ConfigService } from '../common/config';
 import { PrometheusService } from '../common/prometheus';
 import { APP_NAME, APP_VERSION } from './app.constants';
@@ -11,35 +10,16 @@ export class AppService implements OnModuleInit {
   constructor(
     @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
     protected readonly executionProviderService: ExecutionProviderService,
-    protected readonly consensusProviderService: ConsensusProviderService,
     protected readonly configService: ConfigService,
     protected readonly prometheusService: PrometheusService,
   ) {}
 
   public async onModuleInit(): Promise<void> {
-    if (this.configService.get('VALIDATOR_REGISTRY_ENABLE')) {
-      await this.validateNetwork();
-    }
-
     const env = this.configService.get('NODE_ENV');
     const version = APP_VERSION;
     const name = APP_NAME;
     const network = await this.executionProviderService.getNetworkName();
     this.prometheusService.buildInfo.labels({ env, name, version, network }).inc();
-    this.logger.log('Init app', { env, name, version });
-  }
-
-  /**
-   * Validates the CL and EL chains match
-   */
-  protected async validateNetwork(): Promise<void> {
-    const chainId = this.configService.get('CHAIN_ID');
-    const depositContract = await this.consensusProviderService.getDepositContract();
-    const elChainId = await this.executionProviderService.getChainId();
-    const clChainId = Number(depositContract.data?.chain_id);
-
-    if (chainId !== elChainId || elChainId !== clChainId) {
-      throw new Error('Execution and consensus chain ids do not match');
-    }
+    this.logger.log('Init app', { env, name, version, network });
   }
 }

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { JobsService } from './jobs.service';
+import { NetworkValidationModule } from '../network-validation';
 import { KeysUpdateModule } from './keys-update/keys-update.module';
 import { ValidatorsUpdateModule } from './validators-update/validators-update.module';
 
 @Module({
-  imports: [KeysUpdateModule, ValidatorsUpdateModule],
+  imports: [NetworkValidationModule, KeysUpdateModule, ValidatorsUpdateModule],
   providers: [JobsService],
 })
 export class JobsModule {}

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
+import { NetworkValidationService } from '../network-validation';
 import { ValidatorsUpdateService } from './validators-update/validators-update.service';
 import { KeysUpdateService } from './keys-update';
 import { SchedulerRegistry } from '@nestjs/schedule';
@@ -9,6 +10,7 @@ import { PrometheusService } from 'common/prometheus';
 export class JobsService implements OnModuleInit, OnModuleDestroy {
   constructor(
     @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly networkValidationService: NetworkValidationService,
     protected readonly keysUpdateService: KeysUpdateService,
     protected readonly validatorUpdateService: ValidatorsUpdateService,
     protected readonly schedulerRegistry: SchedulerRegistry,
@@ -16,6 +18,10 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   public async onModuleInit(): Promise<void> {
+    this.logger.log('Started network config and DB validation');
+    await this.networkValidationService.validate();
+    this.logger.log('Finished network config and DB validation');
+
     // Do not wait for initialization to avoid blocking the main process
     this.initialize().catch((err) => this.logger.error(err));
   }

--- a/src/migrations/Migration20240427195401.ts
+++ b/src/migrations/Migration20240427195401.ts
@@ -1,0 +1,16 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20240427195401 extends Migration {
+  async up(): Promise<void> {
+    this.addSql(
+      'create table "app_info_entity" ("chain_id" serial primary key, "locator_address" varchar(42) not null);',
+    );
+    this.addSql(
+      'alter table "app_info_entity" add constraint "app_info_entity_locator_address_unique" unique ("locator_address");',
+    );
+  }
+
+  async down(): Promise<void> {
+    this.addSql('drop table if exists "app_info_entity" cascade;');
+  }
+}

--- a/src/mikro-orm.config.ts
+++ b/src/mikro-orm.config.ts
@@ -11,6 +11,7 @@ import { ConsensusValidatorEntity } from '@lido-nestjs/validators-registry';
 import { readFileSync } from 'fs';
 import { SrModuleEntity } from './storage/sr-module.entity';
 import { ElMetaEntity } from './storage/el-meta.entity';
+import { AppInfoEntity } from './storage/app-info.entity';
 import { Logger } from '@nestjs/common';
 
 dotenv.config();
@@ -126,6 +127,7 @@ const config: Options = {
     ConsensusMetaEntity,
     SrModuleEntity,
     ElMetaEntity,
+    AppInfoEntity,
   ],
   migrations: getMigrationOptions(path.join(__dirname, 'migrations'), ['@lido-nestjs/validators-registry']),
 };

--- a/src/network-validation/index.ts
+++ b/src/network-validation/index.ts
@@ -1,0 +1,2 @@
+export * from './network-validation.module';
+export * from './network-validation.service';

--- a/src/network-validation/network-validation.constants.ts
+++ b/src/network-validation/network-validation.constants.ts
@@ -1,0 +1,4 @@
+export const MODULE_ADDRESSES_FOR_CHAINS = {
+  1: '0x55032650b14df07b85bf18a3a3ec8e0af2e028d5',
+  17000: '0x595f64ddc3856a3b5ff4f4cc1d1fb4b46cfd2bac',
+};

--- a/src/network-validation/network-validation.module.ts
+++ b/src/network-validation/network-validation.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { NetworkValidationService } from './network-validation.service';
+
+@Module({
+  providers: [NetworkValidationService],
+  exports: [NetworkValidationService],
+})
+export class NetworkValidationModule {}

--- a/src/network-validation/network-validation.service.ts
+++ b/src/network-validation/network-validation.service.ts
@@ -1,0 +1,84 @@
+import { MikroORM, UseRequestContext } from '@mikro-orm/core';
+import { Inject, Injectable, LoggerService } from '@nestjs/common';
+import { LidoLocator, LIDO_LOCATOR_CONTRACT_TOKEN } from '@lido-nestjs/contracts';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { ConfigService } from '../common/config';
+import { ConsensusProviderService } from '../common/consensus-provider';
+import { ExecutionProviderService } from '../common/execution-provider';
+import { RegistryKeyStorageService, RegistryOperatorStorageService } from '../common/registry';
+import { SRModuleStorageService } from '../storage/sr-module.storage';
+import { AppInfoStorageService } from '../storage/app-info.storage';
+import { MODULE_ADDRESSES_FOR_CHAINS } from './network-validation.constants';
+
+@Injectable()
+export class NetworkValidationService {
+  constructor(
+    protected readonly orm: MikroORM,
+    @Inject(LIDO_LOCATOR_CONTRACT_TOKEN) protected readonly contract: LidoLocator,
+    @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly configService: ConfigService,
+    protected readonly consensusProviderService: ConsensusProviderService,
+    protected readonly executionProviderService: ExecutionProviderService,
+    protected readonly keyStorageService: RegistryKeyStorageService,
+    protected readonly moduleStorageService: SRModuleStorageService,
+    protected readonly operatorStorageService: RegistryOperatorStorageService,
+    protected readonly appInfoStorageService: AppInfoStorageService,
+  ) {}
+
+  @UseRequestContext()
+  public async validate(): Promise<void> {
+    const configChainId = this.configService.get('CHAIN_ID');
+    const elChainId = await this.executionProviderService.getChainId();
+
+    if (this.configService.get('VALIDATOR_REGISTRY_ENABLE')) {
+      const depositContract = await this.consensusProviderService.getDepositContract();
+      const clChainId = Number(depositContract.data?.chain_id);
+
+      if (configChainId !== elChainId || elChainId !== clChainId) {
+        throw new Error('Execution and consensus chain ids do not match');
+      }
+    }
+
+    const [dbKey, dbCuratedModule, dbOperator] = await Promise.all([
+      await this.keyStorageService.find({}, { limit: 1 }),
+      await this.moduleStorageService.findOneById(1),
+      await this.operatorStorageService.find({}, { limit: 1 }),
+    ]);
+
+    if (dbKey.length === 0 && dbCuratedModule == null && dbOperator.length === 0) {
+      this.logger.log('DB is empty, write chain info into DB');
+      return await this.appInfoStorageService.update({
+        chainId: configChainId,
+        locatorAddress: this.contract.address,
+      });
+    }
+
+    const appInfo = await this.appInfoStorageService.get();
+
+    if (appInfo != null) {
+      if (appInfo.chainId !== configChainId || appInfo.locatorAddress !== this.contract.address) {
+        throw new Error(
+          `Chain configuration mismatch. Database is not empty and contains information for chain ${appInfo.chainId} and locator address ${appInfo.locatorAddress}, but the service is trying to start for chain ${configChainId} and locator address ${this.contract.address}`,
+        );
+      }
+
+      return;
+    }
+
+    if (dbCuratedModule == null) {
+      throw new Error('Inconsistent data in database. Some DB tables are empty, but some are not.');
+    }
+
+    if (dbCuratedModule.stakingModuleAddress !== MODULE_ADDRESSES_FOR_CHAINS[configChainId]) {
+      throw new Error(
+        `Chain configuration mismatch. Service is trying to start for chain ${configChainId}, but DB contains data for another chain.`,
+      );
+    }
+
+    this.logger.log('DB is not empty and chain info is not found in DB, write chain info into DB');
+    await this.appInfoStorageService.update({
+      chainId: configChainId,
+      locatorAddress: this.contract.address,
+    });
+  }
+}

--- a/src/storage/app-info.entity.ts
+++ b/src/storage/app-info.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, EntityRepositoryType, PrimaryKey, Property, Unique } from '@mikro-orm/core';
+import { ADDRESS_LEN } from '../common/registry/storage/constants';
+import { AppInfoRepository } from './app-info.repository';
+
+@Entity({ customRepository: () => AppInfoRepository })
+export class AppInfoEntity {
+  [EntityRepositoryType]?: AppInfoRepository;
+
+  constructor(info: AppInfoEntity) {
+    this.chainId = info.chainId;
+    this.locatorAddress = info.locatorAddress;
+  }
+
+  @PrimaryKey()
+  chainId: number;
+
+  @Unique()
+  @Property({
+    length: ADDRESS_LEN,
+  })
+  locatorAddress: string;
+}

--- a/src/storage/app-info.repository.ts
+++ b/src/storage/app-info.repository.ts
@@ -1,0 +1,4 @@
+import { EntityRepository } from '@mikro-orm/knex';
+import { AppInfoEntity } from './app-info.entity';
+
+export class AppInfoRepository extends EntityRepository<AppInfoEntity> {}

--- a/src/storage/app-info.storage.ts
+++ b/src/storage/app-info.storage.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { AppInfoEntity } from './app-info.entity';
+import { AppInfoRepository } from './app-info.repository';
+
+@Injectable()
+export class AppInfoStorageService {
+  constructor(private readonly repository: AppInfoRepository) {}
+
+  async get(): Promise<AppInfoEntity | null> {
+    const result = await this.repository.find({}, { limit: 1 });
+    return result[0] ?? null;
+  }
+
+  async update(appInfo: AppInfoEntity): Promise<void> {
+    await this.repository.nativeDelete({});
+    await this.repository.persist(
+      new AppInfoEntity({
+        chainId: appInfo.chainId,
+        locatorAddress: appInfo.locatorAddress,
+      }),
+    );
+    await this.repository.flush();
+  }
+
+  async removeAll() {
+    return await this.repository.nativeDelete({});
+  }
+}

--- a/src/storage/storage.module.ts
+++ b/src/storage/storage.module.ts
@@ -4,15 +4,17 @@ import { ElMetaEntity } from './el-meta.entity';
 import { ElMetaStorageService } from './el-meta.storage';
 import { SrModuleEntity } from './sr-module.entity';
 import { SRModuleStorageService } from './sr-module.storage';
+import { AppInfoEntity } from './app-info.entity';
+import { AppInfoStorageService } from './app-info.storage';
 
 @Global()
 @Module({
   imports: [
     MikroOrmModule.forFeature({
-      entities: [SrModuleEntity, ElMetaEntity],
+      entities: [SrModuleEntity, ElMetaEntity, AppInfoEntity],
     }),
   ],
-  providers: [SRModuleStorageService, ElMetaStorageService],
-  exports: [SRModuleStorageService, ElMetaStorageService],
+  providers: [SRModuleStorageService, ElMetaStorageService, AppInfoStorageService],
+  exports: [SRModuleStorageService, ElMetaStorageService, AppInfoStorageService],
 })
 export class StorageModule {}


### PR DESCRIPTION
Implement a sanity checker that checks that the information stored in the DB corresponds the chain for which the app is run. If the app is run for one chain, and the DB contains data for another chain, the sanity checker prevents the app from start and throws the error.