### PR TITLE
Workflows for build reproducibility and hashes checking

### DIFF
--- a/.github/workflows/build_and_show_hashes.yml
+++ b/.github/workflows/build_and_show_hashes.yml
@@ -78,5 +78,6 @@ jobs:
 
       - name: Report summary
         run: |
+          echo "commit hash: $(git rev-parse HEAD)"
           echo "tar sha256 for image is ${{ steps.hash.outputs.sha256 }}"
           echo "image digest is ${{ steps.digest.outputs.digest }}"

--- a/.github/workflows/build_and_show_hashes.yml
+++ b/.github/workflows/build_and_show_hashes.yml
@@ -1,0 +1,82 @@
+---
+name: Build and show hashes
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'Git commit hash'
+        required: true
+        type: string
+
+jobs:
+  build:
+    name: Build image
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+      digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Checkout specified commit
+        run: |
+          git checkout ${{ inputs.commit }}
+
+      - name: Set up builder
+        id: builder
+        uses: docker/setup-buildx-action@v3.10.0
+
+      - name: Set up crane
+        # latest at 2025-04-14
+        run: |
+          docker create --name temp_container gcr.io/go-containerregistry/crane@sha256:fc86bcad43a000c2a1ca926a1e167db26c053cebc3fa5d14285c72773fb8c11d
+          docker cp temp_container:/ko-app/crane crane
+          sudo mv crane /usr/local/bin/crane
+
+      - name: Build locally and save to file
+        id: build
+        uses: docker/build-push-action@v6.15.0
+        with:
+          push: false
+          load: true
+          # image save to tar resets all timestamps in all layers (rewrite-timestamp=true)
+          outputs: type=docker,rewrite-timestamp=true,dest=image.tar
+          # it's either reproducible, or have provenance, it's impossible to have both
+          provenance: false
+          builder: "${{ steps.builder.outputs.name }}"
+          build-args: ""
+        env:
+          # https://docs.docker.com/build/ci/github-actions/reproducible-builds/
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Load cleansed image back
+        id: load
+        run: |
+          set -e
+          IMAGE=$(docker load -i "image.tar" | awk -F': ' '{print $2}')
+          docker tag "$IMAGE" "image"
+        shell: bash
+
+      - name: Compute SHA256
+        id: hash
+        run: echo "sha256=$(sha256sum image.tar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute digest
+        id: digest
+        run:
+          echo "digest=$(crane digest --tarball image.tar)" >> "$GITHUB_OUTPUT"
+
+      - name: Report summary
+        run: |
+          echo "tar sha256 for image is ${{ steps.hash.outputs.sha256 }}"
+          echo "image digest is ${{ steps.digest.outputs.digest }}"

--- a/.github/workflows/build_and_show_hashes.yml
+++ b/.github/workflows/build_and_show_hashes.yml
@@ -81,3 +81,6 @@ jobs:
           echo "commit hash: $(git rev-parse HEAD)"
           echo "tar sha256 for image is ${{ steps.hash.outputs.sha256 }}"
           echo "image digest is ${{ steps.digest.outputs.digest }}"
+          echo "➤ **Commit Hash:** \`$(git rev-parse HEAD)\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "➤ **tar SHA256:** \`${{ steps.hash.outputs.sha256 }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "➤ **Image Digest:** \`${{ steps.digest.outputs.digest }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test_docker_build_reproducibility.yml
+++ b/.github/workflows/test_docker_build_reproducibility.yml
@@ -1,0 +1,159 @@
+---
+name: Test Docker image reproducibility
+
+"on":
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6.15.0
+        with:
+          push: false
+          load: true
+          outputs: type=docker,dest=image.tar,rewrite-timestamp=true
+          provenance: false
+        env:
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Compute SHA256
+        id: hash
+        run: echo "sha256=$(sha256sum image.tar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Report image hash
+        run: |
+          echo "Hash from the second image build: ${{ steps.hash.outputs.sha256 }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-image-tar
+          path: image.tar
+
+  rebuild:
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          load: true
+          outputs: type=docker,dest=image.tar,rewrite-timestamp=true
+          provenance: false
+        env:
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Compute SHA256
+        id: hash
+        run: echo "sha256=$(sha256sum image.tar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Report image hash
+        run: |
+          echo "Hash from the second image build: ${{ steps.hash.outputs.sha256 }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rebuild-image-tar
+          path: image.tar
+
+  reproducability:
+    name: Check reproducability
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - rebuild
+    steps:
+      - name: Fail if empty
+        if: ${{ needs.build.outputs.sha256 == '' }}
+        run: |
+          echo needs.build.outputs.sha256 is ${{ needs.build.outputs.sha256 }}
+          exit 1
+      - name: Report image Hash
+        run: |
+          echo "Hash from the first image build: ${{ needs.build.outputs.sha256 }}"
+          echo "Hash from the second image build: ${{ needs.rebuild.outputs.sha256 }}"
+
+      - name: Check if match
+        if: ${{ needs.build.outputs.sha256 != needs.rebuild.outputs.sha256 }}
+        run: |
+          echo ${{ needs.build.outputs.sha256 }} != ${{ needs.rebuild.outputs.sha256 }}
+          echo Image is not reproducible
+          echo "::error::Image is not reproducible"
+          exit 1
+
+  diffoscope:
+    name: Report difference
+    needs:
+      - build
+      - rebuild
+    if: ${{ needs.build.outputs.sha256 != needs.rebuild.outputs.sha256 }}
+    runs-on: ubuntu-24.04
+    container:
+      # latest at 2025-05-03
+      image: registry.salsa.debian.org/reproducible-builds/diffoscope@sha256:9a6780b2a83f885ae917043d0dd71038d70bebd56dd8d24d00d7de91da7a8454
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-image-tar
+          path: build
+
+      - name: Download rebuild artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: rebuild-image-tar
+          path: rebuild
+
+      - name: Run diffoscope
+        run: diffoscope build/image.tar rebuild/image.tar --fuzzy-threshold 400 --html report.html --output-empty
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: report
+          path: report.html

--- a/.github/workflows/test_docker_build_reproducibility.yml
+++ b/.github/workflows/test_docker_build_reproducibility.yml
@@ -101,8 +101,8 @@ jobs:
           name: rebuild-image-tar
           path: image.tar
 
-  reproducability:
-    name: Check reproducability
+  reproducibility:
+    name: Check reproducibility
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
[SRE-2757](https://linear.app/lidofi/issue/SRE-2757)

This brings two new workflows:

* **Test Docker image reproducibility** - for checking build reproducibility, because without that we can't be sure in resulting image consistency. It [builds](https://github.com/lidofinance/lido-keys-api/actions/runs/15577442269) image two times and compares resulting artifacts. In case of any difference detected - shows the report. It will be triggered on pull requests and is also available for running manually.
* **Build and show hashes** - for building image and showing hashes. Can be triggered only manually and needs commit hash as an input.

Second workflow needs to be checked in real conditions, because KAPI image was never built with our updated workflows yet. Output example:
![output_example](https://github.com/user-attachments/assets/88c49be1-25a7-43f1-9830-719bdeb0fb3c)