### PR TITLE
Endpoint validation

### DIFF
--- a/src/common/decorators/isAddress.ts
+++ b/src/common/decorators/isAddress.ts
@@ -1,0 +1,42 @@
+import {
+  registerDecorator,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { isAddress } from 'ethers/lib/utils';
+
+@ValidatorConstraint({ name: 'IsAddressConstraint', async: false })
+export class IsAddressConstraint implements ValidatorConstraintInterface {
+  validate(value: any, args: ValidationArguments): boolean {
+    const [isEach] = args.constraints as [boolean];
+
+    const isValid = (val: any): boolean => typeof val === 'string' && isAddress(val);
+
+    if (isEach && Array.isArray(value)) {
+      return value.every(isValid);
+    }
+
+    return isValid(value);
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return `Each value must be a valid address`;
+  }
+}
+
+export function IsAddress(validationOptions?: ValidationOptions) {
+  const each = validationOptions?.each === true;
+
+  return function (object: Record<string, any>, propertyName: string) {
+    registerDecorator({
+      name: 'IsAddress',
+      target: object.constructor,
+      propertyName,
+      constraints: [each],
+      options: validationOptions,
+      validator: IsAddressConstraint,
+    });
+  };
+}

--- a/src/common/decorators/isAddress.ts
+++ b/src/common/decorators/isAddress.ts
@@ -5,14 +5,14 @@ import {
   ValidationArguments,
   ValidationOptions,
 } from 'class-validator';
-import { isAddress } from 'ethers/lib/utils';
+import { isAddress as isAddressValidation } from 'ethers/lib/utils';
 
 @ValidatorConstraint({ name: 'IsAddressConstraint', async: false })
 export class IsAddressConstraint implements ValidatorConstraintInterface {
   validate(value: any, args: ValidationArguments): boolean {
     const [isEach] = args.constraints as [boolean];
 
-    const isValid = (val: any): boolean => typeof val === 'string' && isAddress(val);
+    const isValid = (val: any): boolean => typeof val === 'string' && isAddressValidation(val);
 
     if (isEach && Array.isArray(value)) {
       return value.every(isValid);

--- a/src/common/decorators/isPubkey.ts
+++ b/src/common/decorators/isPubkey.ts
@@ -1,0 +1,42 @@
+import {
+  registerDecorator,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+  ValidationOptions,
+} from 'class-validator';
+import { isHexString } from 'ethers/lib/utils';
+
+@ValidatorConstraint({ name: 'IsPubkeyConstraint', async: false })
+export class IsPubkeyConstraint implements ValidatorConstraintInterface {
+  validate(value: any, args: ValidationArguments) {
+    const [isEach] = args.constraints as [boolean];
+
+    const isValid = (val: any): boolean => typeof val === 'string' && val.startsWith('0x') && isHexString(val, 48);
+
+    if (isEach && Array.isArray(value)) {
+      return value.every((v) => isValid(v));
+    }
+
+    return isValid(value);
+  }
+
+  defaultMessage(args: ValidationArguments) {
+    return `Each pubkey must be a valid 0x-prefixed 48-byte hex string`;
+  }
+}
+
+export function IsPubkey(validationOptions?: ValidationOptions) {
+  const each = validationOptions?.each === true;
+
+  return function (object: Record<string, any>, propertyName: string) {
+    registerDecorator({
+      name: 'IsPubkey',
+      target: object.constructor,
+      propertyName,
+      constraints: [each],
+      options: validationOptions,
+      validator: IsPubkeyConstraint,
+    });
+  };
+}

--- a/src/http/common/entities/key-query.ts
+++ b/src/http/common/entities/key-query.ts
@@ -1,21 +1,16 @@
 import { BadRequestException } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { Transform, Type } from 'class-transformer';
+import { Transform } from 'class-transformer';
 import { IsInt, IsBoolean, IsOptional, Min } from 'class-validator';
+import { IsAddress } from 'common/decorators/isAddress';
 
-const toBoolean = (value, propertyName: string): boolean => {
-  if (value === 'true') {
-    return true;
-  }
-
-  if (value == 'false') {
-    return false;
-  }
-
-  throw new BadRequestException([`${propertyName.toLocaleLowerCase()} must be a boolean value`]);
+const toBoolean = (value: any, propertyName: string): boolean | undefined => {
+  if (value === '') return undefined;
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new BadRequestException([`${propertyName.toLowerCase()} must be a boolean value`]);
 };
 
-// TODO: use it in staking-module-service
 export class KeyQuery {
   @ApiProperty({
     required: false,
@@ -32,9 +27,9 @@ export class KeyQuery {
     description:
       'Filter for operator with specified index. If this value is not specified endpoint will return keys for all operators.',
   })
+  @Transform(({ value }) => (value === '' ? undefined : Number(value)))
   @IsInt()
   @Min(0)
-  @Type(() => Number)
   @IsOptional()
   operatorIndex?: number;
 }
@@ -43,6 +38,7 @@ export class KeyQueryWithAddress extends KeyQuery {
   @ApiProperty({ isArray: true, type: String, required: false, description: 'Module address list' })
   @Transform(({ value }) => (Array.isArray(value) ? value : Array(value)))
   @Transform(({ value }) => value.map((v) => v.toLowerCase()))
+  @IsAddress({ each: true })
   @IsOptional()
   moduleAddresses!: string[];
 }

--- a/src/http/common/entities/operator-id.ts
+++ b/src/http/common/entities/operator-id.ts
@@ -1,14 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
-import { IsInt, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { IsDefined, IsInt, Min } from 'class-validator';
 
 export class OperatorId {
+  @Transform(({ value }) => (value === '' ? undefined : Number(value)))
   @ApiProperty({
     name: 'operator_id',
     description: 'Operator index',
   })
+  @IsDefined()
   @IsInt()
   @Min(0)
-  @Type(() => Number)
   operator_id!: number;
 }

--- a/src/http/common/entities/pubkey.ts
+++ b/src/http/common/entities/pubkey.ts
@@ -1,0 +1,6 @@
+import { IsPubkey } from 'common/decorators/isPubkey';
+
+export class Pubkey {
+  @IsPubkey()
+  pubkey!: string;
+}

--- a/src/http/common/entities/pubkeys.ts
+++ b/src/http/common/entities/pubkeys.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsArray, ArrayMinSize, IsString } from 'class-validator';
+import { IsArray, ArrayMinSize } from 'class-validator';
+import { IsPubkey } from 'common/decorators/isPubkey';
 
 export class KeysFindBody {
   @ApiProperty({
@@ -8,6 +9,6 @@ export class KeysFindBody {
   })
   @IsArray()
   @ArrayMinSize(1)
-  @IsString({ each: true })
+  @IsPubkey({ each: true })
   pubkeys!: string[];
 }

--- a/src/http/common/pipeline/module-id-pipe.ts
+++ b/src/http/common/pipeline/module-id-pipe.ts
@@ -9,7 +9,6 @@ export class ModuleIdPipe implements PipeTransform<string, string | number> {
     if (isAddress(trimmedValue)) {
       const normalized = trimmedValue.toLowerCase();
 
-      // Optional: reject zero address
       if (normalized === AddressZero) {
         throw new BadRequestException(['module_id cannot be the zero address']);
       }

--- a/src/http/common/pipeline/module-id-pipe.ts
+++ b/src/http/common/pipeline/module-id-pipe.ts
@@ -1,12 +1,20 @@
 import { BadRequestException, PipeTransform } from '@nestjs/common';
 import { isAddress } from 'ethers/lib/utils';
+import { AddressZero } from '@ethersproject/constants';
 
 export class ModuleIdPipe implements PipeTransform<string, string | number> {
   transform(value: string) {
     const trimmedValue = value.trim();
 
     if (isAddress(trimmedValue)) {
-      return trimmedValue.toLowerCase();
+      const normalized = trimmedValue.toLowerCase();
+
+      // Optional: reject zero address
+      if (normalized === AddressZero) {
+        throw new BadRequestException(['module_id cannot be the zero address']);
+      }
+
+      return normalized;
     }
 
     const nonNegativeIntegerRegex = /^(0|[1-9]\d*)$/;
@@ -15,6 +23,6 @@ export class ModuleIdPipe implements PipeTransform<string, string | number> {
       return Number(trimmedValue);
     }
 
-    throw new BadRequestException([`module_id must be a contract address or numeric value`]);
+    throw new BadRequestException(['module_id must be a contract address or numeric value']);
   }
 }

--- a/src/http/db.fixtures.ts
+++ b/src/http/db.fixtures.ts
@@ -171,6 +171,16 @@ export const dvtModuleKeys: RegistryKey[] = [
     used: true,
     vetted: false,
   },
+  {
+    operatorIndex: 2,
+    index: 17,
+    moduleAddress: dvtModule.stakingModuleAddress,
+    key: '0xa544bc44d9eacbf4dd6a2d6087b43f4c67fd5618651b97effcb30997bf49e5d7acf0100ef14e5d087cc228bc78d498e6',
+    depositSignature:
+      '0x967875a0104d9f674538e2ec0df4be0a61ef08061cdcfa83e5a63a43dadb772d29053368224e5d8e046ba1a78490f5fc0f0186f23af0465d0a82b2db2e7535782fe12e1fd1cd4f6eb77d8dc7a4f7ab0fde31435d5fa98a013e0a716c5e1ef6a2',
+    used: true,
+    vetted: true,
+  },
 ];
 
 export const curatedKeyWithDuplicate: RegistryKey = {

--- a/src/http/keys/keys.controller.ts
+++ b/src/http/keys/keys.controller.ts
@@ -24,6 +24,7 @@ import { TooEarlyResponse } from '../common/entities/http-exceptions';
 import * as JSONStream from 'jsonstream';
 import { EntityManager } from '@mikro-orm/knex';
 import { IsolationLevel } from '@mikro-orm/core';
+import { Pubkey } from 'http/common/entities/pubkey';
 
 @Controller('keys')
 @ApiTags('keys')
@@ -99,9 +100,8 @@ export class KeysController {
     type: KeyListResponse,
   })
   @ApiOperation({ summary: 'Get detailed information about pubkey' })
-  // TODO: add check that pubkey has a right pattern
-  getByPubkey(@Param('pubkey') pubkey: string) {
-    return this.keysService.getByPubkey(pubkey);
+  getByPubkey(@Param() data: Pubkey) {
+    return this.keysService.getByPubkey(data.pubkey);
   }
 
   @Version('1')
@@ -119,7 +119,6 @@ export class KeysController {
   })
   @ApiOperation({ summary: 'Get list of found keys in DB from pubkey list' })
   getByPubkeys(@Body() keys: KeysFindBody) {
-    // TODO: add check that pubkey has a right pattern
     return this.keysService.getByPubkeys(keys.pubkeys);
   }
 }

--- a/src/http/keys/keys.e2e-spec.ts
+++ b/src/http/keys/keys.e2e-spec.ts
@@ -123,127 +123,354 @@ describe('KeyController (e2e)', () => {
         await cleanDB();
       });
 
-      it('should return all keys for request without filters', async () => {
-        // Get all keys without filters
-        const resp = await request(app.getHttpServer()).get('/v1/keys');
+      describe('without filters', () => {
+        it('should return all keys for request without filters', async () => {
+          // Get all keys without filters
+          const resp = await request(app.getHttpServer()).get('/v1/keys');
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(keys.length);
-        expect(resp.body.data).toEqual(
-          expect.arrayContaining([...curatedModuleKeysResponse, ...dvtModuleKeysResponse]),
-        );
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(keys.length);
+          expect(resp.body.data).toEqual(
+            expect.arrayContaining([...curatedModuleKeysResponse, ...dvtModuleKeysResponse]),
+          );
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
       });
 
-      it('should return used keys', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: true });
+      describe('used + operatorIndex validation', () => {
+        it('should return used keys', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: true });
 
-        const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter((key) => key.used);
+          const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter((key) => key.used);
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(expectedKeys.length);
-        expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(expectedKeys.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('should return unused keys', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false });
+          const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter((key) => !key.used);
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(expectedKeys.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('should return used keys for operator 1', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: true, operatorIndex: 1 });
+          const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter(
+            (key) => key.used && key.operatorIndex == 1,
+          );
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(expectedKeys.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('should return unused keys for operator 1', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 1 });
+          const expectedKeys = [...dvtModuleKeysResponse, ...curatedModuleKeysResponse].filter(
+            (key) => !key.used && key.operatorIndex == 1,
+          );
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(expectedKeys.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('should return an empty list of keys for unused keys request with operator 2', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 2 });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
       });
 
-      it('should return unused keys', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false });
-        const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter((key) => !key.used);
+      describe('validate operatorIndex', () => {
+        it('should return 400 error if operatorIndex is not a number', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 'one' });
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operatorIndex must not be less than 0', 'operatorIndex must be an integer number'],
+            statusCode: 400,
+          });
+        });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(expectedKeys.length);
-        expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+        it('should return 400 error if operatorIndex is a negative value', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: -1 });
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operatorIndex must not be less than 0'],
+            statusCode: 400,
+          });
+        });
+
+        it("should return empty list if operator doesn't exist", async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ operatorIndex: 3 });
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('Should return 400 error if operatorIndex is a float', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ operatorIndex: 1.5 });
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operatorIndex must be an integer number'],
+            statusCode: 400,
+          });
+        });
+
+        //   const resp = await request(app.getHttpServer())
+        //     .get(`/v1/modules/${dvtModule.moduleId}/operators/keys`)
+        //     .query({ operatorIndex: 0 });
+
+        //   expect(resp.status).toEqual(200);
+        //   expect(resp.body.data.operators).toEqual([]);
+        //   expect(resp.body.data.keys).toEqual([]);
+        //   expect(resp.body.data.module).toEqual(dvtModuleResp);
+        //   expect(resp.body.meta).toEqual({
+        //     elBlockSnapshot: {
+        //       blockNumber: elMeta.number,
+        //       blockHash: elMeta.hash,
+        //       timestamp: elMeta.timestamp,
+        //       lastChangedBlockHash: elMeta.lastChangedBlockHash,
+        //     },
+        //   });
+        // });
+
+        it('Should not filter by operatorIndex if operatorIndex provided as empty string', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ operatorIndex: '' });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(keys.length);
+          expect(resp.body.data).toEqual(
+            expect.arrayContaining([...curatedModuleKeysResponse, ...dvtModuleKeysResponse]),
+          );
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
       });
 
-      it('should return used keys for operator 1', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: true, operatorIndex: 1 });
-        const expectedKeys = [...curatedModuleKeysResponse, ...dvtModuleKeysResponse].filter(
-          (key) => key.used && key.operatorIndex == 1,
-        );
+      describe('validate used filter', () => {
+        it('should return 400 error if used is not a boolean value', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: 0, operatorIndex: 2 });
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['used must be a boolean value'],
+            statusCode: 400,
+          });
+        });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(expectedKeys.length);
-        expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+        it('Should return 400 error if used is wrong string value', async () => {
+          const resp = await request(app.getHttpServer())
+            .get('/v1/keys')
+            .query({ used: 'somethingwrong', operatorIndex: 2 });
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['used must be a boolean value'],
+            statusCode: 400,
+          });
+        });
+
+        it('Should ignore used filter, if used provided as empty string', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: '', operatorIndex: 1 });
+
+          const curatedModuleKeys = curatedModuleKeysResponse.filter((key) => key.operatorIndex == 1);
+          const dvtModuleKeys = dvtModuleKeysResponse.filter((key) => key.operatorIndex == 1);
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual([...curatedModuleKeys, ...dvtModuleKeys].length);
+          expect(resp.body.data).toEqual(expect.arrayContaining([...curatedModuleKeys, ...dvtModuleKeys]));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('Should return 400 error if used is the string "undefined"', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: 'undefined' });
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['used must be a boolean value'],
+            statusCode: 400,
+          });
         });
       });
 
-      it('should return unused keys for operator 1', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 1 });
-        const expectedKeys = [...dvtModuleKeysResponse, ...curatedModuleKeysResponse].filter(
-          (key) => !key.used && key.operatorIndex == 1,
-        );
+      describe('validate moduleAddresses', () => {
+        it('should return only keys from dvtModule if one module address is provided', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({
+            moduleAddresses: dvtModule.stakingModuleAddress,
+          });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(expectedKeys.length);
-        expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(dvtModuleKeysResponse.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtModuleKeysResponse));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
-      });
 
-      it('should return an empty list of keys for unused keys request with operator 2', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 2 });
+        it('should return keys from both modules if both addresses are provided', async () => {
+          const resp = await request(app.getHttpServer())
+            .get('/v1/keys')
+            .query({
+              moduleAddresses: [dvtModule.stakingModuleAddress, curatedModule.stakingModuleAddress],
+            });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
+          const expectedKeys = [...dvtModuleKeysResponse, ...curatedModuleKeysResponse];
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(expectedKeys.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(expectedKeys));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
-      });
 
-      it('should return 400 error if operatorIndex is not a number', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: false, operatorIndex: 'one' });
-        expect(resp.status).toEqual(400);
-        expect(resp.body).toEqual({
-          error: 'Bad Request',
-          message: ['operatorIndex must not be less than 0', 'operatorIndex must be an integer number'],
-          statusCode: 400,
+        it('should return empty list if module address does not exist', async () => {
+          const resp = await request(app.getHttpServer())
+            .get('/v1/keys')
+            .query({ moduleAddresses: '0x0000000000000000000000000000000000001234' });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
         });
-      });
 
-      it('should return 400 error if used is not a boolean value', async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ used: 0, operatorIndex: 2 });
-        expect(resp.status).toEqual(400);
-        expect(resp.body).toEqual({ error: 'Bad Request', message: ['used must be a boolean value'], statusCode: 400 });
+        it('should handle empty string as moduleAddresses and ignore the filter', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({
+            moduleAddresses: '',
+          });
+
+          const expectedKeys = [...dvtModuleKeysResponse, ...curatedModuleKeysResponse];
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['Each value must be a valid address'],
+            statusCode: 400,
+          });
+        });
+
+        it('should be case agnostic', async () => {
+          const uppercased = dvtModule.stakingModuleAddress.toUpperCase();
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({
+            moduleAddresses: uppercased,
+          });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(dvtModuleKeysResponse.length);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtModuleKeysResponse));
+          expect(resp.body.meta).toEqual({
+            elBlockSnapshot: {
+              blockNumber: elMeta.number,
+              blockHash: elMeta.hash,
+              timestamp: elMeta.timestamp,
+              lastChangedBlockHash: elMeta.lastChangedBlockHash,
+            },
+          });
+        });
+
+        it('should return 400 if moduleAddresses is not a string or array of strings', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/keys').query({ moduleAddresses: 12345 });
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['Each value must be a valid address'],
+            statusCode: 400,
+          });
+        });
       });
 
       // it('should ignore unknown values in query', async () => {
@@ -256,20 +483,6 @@ describe('KeyController (e2e)', () => {
       //   expect(resp.status).toEqual(200);
       //   expect(getMock).toBeCalledWith({ used: true, operatorIndex: 1 });
       // });
-
-      it("should return empty list if operator doesn't exist", async () => {
-        const resp = await request(app.getHttpServer()).get('/v1/keys').query({ operatorIndex: 3 });
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.meta).toEqual({
-          elBlockSnapshot: {
-            blockNumber: elMeta.number,
-            blockHash: elMeta.hash,
-            timestamp: elMeta.timestamp,
-            lastChangedBlockHash: elMeta.lastChangedBlockHash,
-          },
-        });
-      });
     });
 
     describe('too early response case', () => {
@@ -361,8 +574,9 @@ describe('KeyController (e2e)', () => {
       });
 
       it('Should return an empty list if no keys satisfy the request', async () => {
-        // Get all keys without filters
-        const pubkeys = ['somerandomkey'];
+        const pubkeys = [
+          '0xb554bc44d9eacbf4dd6a2d6087b43f4c67fd5618651b97effcb30997bf49e5d7acf0100ef14e5d087cc228bc78d498e8',
+        ];
 
         const resp = await request(app.getHttpServer())
           .post('/v1/keys/find')
@@ -394,6 +608,20 @@ describe('KeyController (e2e)', () => {
           statusCode: 400,
         });
       });
+
+      it('Should return 400 error if pubkeys list contains not only string values', async () => {
+        const resp = await request(app.getHttpServer())
+          .post(`/v1/keys/find`)
+          .set('Content-Type', 'application/json')
+          .send({ pubkeys: [3, 'sdsdsd'] });
+
+        expect(resp.status).toEqual(400);
+        expect(resp.body).toEqual({
+          error: 'Bad Request',
+          message: ['Each pubkey must be a valid 0x-prefixed 48-byte hex string'],
+          statusCode: 400,
+        });
+      });
     });
   });
 
@@ -411,7 +639,7 @@ describe('KeyController (e2e)', () => {
         // lets save keys
         await keysStorageService.save(keys);
         await moduleStorageService.upsert(curatedModule, 1, '');
-        const resp = await request(app.getHttpServer()).get(`/v1/keys/wrongkey`);
+        const resp = await request(app.getHttpServer()).get(`/v1/keys/${curatedKeyWithDuplicate.key}`);
         expect(resp.status).toEqual(425);
         expect(resp.body).toEqual({ message: 'Too early response', statusCode: 425 });
       });
@@ -452,13 +680,13 @@ describe('KeyController (e2e)', () => {
         });
       });
 
-      it('should return 404 if key was not found', async () => {
+      it('should return 400 if key is not valid pubkey', async () => {
         const resp = await request(app.getHttpServer()).get(`/v1/keys/someunknownkey`);
-        expect(resp.status).toEqual(404);
+        expect(resp.status).toEqual(400);
         expect(resp.body).toEqual({
-          error: 'Not Found',
-          message: 'There are no keys with someunknownkey public key in db.',
-          statusCode: 404,
+          error: 'Bad Request',
+          message: ['Each pubkey must be a valid 0x-prefixed 48-byte hex string'],
+          statusCode: 400,
         });
       });
     });

--- a/src/http/keys/keys.e2e-spec.ts
+++ b/src/http/keys/keys.e2e-spec.ts
@@ -279,25 +279,6 @@ describe('KeyController (e2e)', () => {
             statusCode: 400,
           });
         });
-
-        //   const resp = await request(app.getHttpServer())
-        //     .get(`/v1/modules/${dvtModule.moduleId}/operators/keys`)
-        //     .query({ operatorIndex: 0 });
-
-        //   expect(resp.status).toEqual(200);
-        //   expect(resp.body.data.operators).toEqual([]);
-        //   expect(resp.body.data.keys).toEqual([]);
-        //   expect(resp.body.data.module).toEqual(dvtModuleResp);
-        //   expect(resp.body.meta).toEqual({
-        //     elBlockSnapshot: {
-        //       blockNumber: elMeta.number,
-        //       blockHash: elMeta.hash,
-        //       timestamp: elMeta.timestamp,
-        //       lastChangedBlockHash: elMeta.lastChangedBlockHash,
-        //     },
-        //   });
-        // });
-
         it('Should not filter by operatorIndex if operatorIndex provided as empty string', async () => {
           const resp = await request(app.getHttpServer()).get('/v1/keys').query({ operatorIndex: '' });
 

--- a/src/http/sr-modules-operators/sr-modules-operators.controller.ts
+++ b/src/http/sr-modules-operators/sr-modules-operators.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Version, Param, HttpStatus, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Version, Param, HttpStatus, NotFoundException, ParseIntPipe } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags, ApiParam, ApiNotFoundResponse } from '@nestjs/swagger';
 import {
   GroupedByModuleOperatorListResponse,
@@ -6,9 +6,9 @@ import {
   SRModuleOperatorResponse,
 } from './entities';
 import { SRModulesOperatorsService } from './sr-modules-operators.service';
-import { OperatorId } from '../common/entities/operator-id';
 import { TooEarlyResponse } from '../common/entities/http-exceptions';
 import { ModuleIdPipe } from '../common/pipeline/module-id-pipe';
+import { OperatorId } from 'http/common/entities';
 
 @Controller('/')
 @ApiTags('operators')

--- a/src/http/sr-modules-validators/entities/query.ts
+++ b/src/http/sr-modules-validators/entities/query.ts
@@ -1,15 +1,15 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsOptional, Min } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
 
 export class ValidatorsQuery {
   @ApiProperty({
     required: false,
     description: 'Number of validators to exit. If validators number less than amount, return all validators.',
   })
+  @Transform(({ value }) => (value === '' ? undefined : Number(value)))
   @IsInt()
   @Min(0)
-  @Type(() => Number)
   @IsOptional()
   max_amount?: number;
 
@@ -17,9 +17,9 @@ export class ValidatorsQuery {
     required: false,
     description: 'Percent of validators to exit. Default value is 10. Percent has a higher priority than max_amount',
   })
+  @Transform(({ value }) => (value === '' ? undefined : Number(value)))
   @IsInt()
   @Min(0)
-  @Type(() => Number)
   @IsOptional()
   percent?: number;
 }

--- a/src/http/sr-modules-validators/sr-modules-validators.e2e-spec.ts
+++ b/src/http/sr-modules-validators/sr-modules-validators.e2e-spec.ts
@@ -43,6 +43,7 @@ import {
 } from '../consensus.fixtures';
 import { DatabaseE2ETestingModule } from 'app';
 import { CSMKeyRegistryService } from 'common/registry-csm';
+import { AddressZero } from '@ethersproject/constants';
 
 describe('SRModulesValidatorsController (e2e)', () => {
   let app: INestApplication;
@@ -173,146 +174,162 @@ describe('SRModulesValidatorsController (e2e)', () => {
         await cleanDB();
       });
 
-      it("Should return 10% validators by default for 'dvt' module when 'operator' is set to 'one'", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(
-          `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`,
-        );
+      describe('percent and amount validation', () => {
+        it("Should return 10% validators by default for 'dvt' module when 'operator' is set to 'one'", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`,
+          );
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(1);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp10percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(1);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp10percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it("Should return 100% validators for 'dvt' module when 'operator' is set to 'one'", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: 100 });
+        it("Should return 100% validators for 'dvt' module when 'operator' is set to 'one'", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: 100 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it("Should prioritize 'percent' over 'max_amount' when both are provided in the query", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: 20, max_amount: 5 });
+        it("Should prioritize 'percent' over 'max_amount' when both are provided in the query", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: 20, max_amount: 5 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(2);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp20percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(2);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp20percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 5 validators when max_amount is 5', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ max_amount: 5 });
+        it('Should return 5 validators when max_amount is 5', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ max_amount: 5 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(5);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp5maxAmount));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(5);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp5maxAmount));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 100% validators when max_amount exceeds the total validator amount', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ max_amount: 100 });
+        it('Should return 100% validators when max_amount exceeds the total validator amount', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ max_amount: 100 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 100% validators when percent exceeds the total validator amount', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: 200 });
+        it('Should return 100% validators when percent exceeds the total validator amount', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: 200 });
 
-        // sometime get 400
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          // sometime get 400
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return empty list of validators when percent equal to 0', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: 0 });
+        it('Should return empty list of validators when percent equal to 0', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: 0 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return empty list of validators when max_amount equal to 0', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: 0 });
+        it('Should return empty list of validators when max_amount equal to 0', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: 0 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 400 error if percent or max_amount are negative', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ percent: -1, max_amount: -1 });
+        it('Should return 400 error if percent or max_amount are negative', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ percent: -1, max_amount: -1 });
 
-        expect(resp.status).toEqual(400);
-        expect(resp.body.message).toEqual(
-          expect.arrayContaining(['max_amount must not be less than 0', 'percent must not be less than 0']),
-        );
-      });
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining(['max_amount must not be less than 0', 'percent must not be less than 0']),
+          );
+        });
 
-      it('Should return 400 error if percent or max_amount is not number', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
-          .query({ max_amount: 'dfsdfds', percent: 'sdsdfsf' });
+        it('Should return 400 error if percent or max_amount is not number', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ max_amount: 'dfsdfds', percent: 'sdsdfsf' });
 
-        expect(resp.status).toEqual(400);
-        expect(resp.body.message).toEqual(
-          expect.arrayContaining([
-            'max_amount must not be less than 0',
-            'max_amount must be an integer number',
-            'percent must not be less than 0',
-            'percent must be an integer number',
-          ]),
-        );
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining([
+              'max_amount must not be less than 0',
+              'max_amount must be an integer number',
+              'percent must not be less than 0',
+              'percent must be an integer number',
+            ]),
+          );
+        });
+
+        it('Should return 10% validators by default if percent or max_amount are not set', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1`)
+            .query({ max_amount: '', percent: '' });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(1);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneResp10percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
+        });
       });
 
       it("Should return a 500 error if 'el_meta' is older than 'cl_meta'", async () => {
@@ -330,28 +347,132 @@ describe('SRModulesValidatorsController (e2e)', () => {
         });
       });
 
-      it('Should return a 404 error if the requested module does not exist', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(`/v1/modules/777/validators/validator-exits-to-prepare/1`);
+      describe('validate module id', () => {
+        it('Should return a 404 error if the requested module does not exist', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            '/v1/modules/777/validators/validator-exits-to-prepare/1',
+          );
 
-        expect(resp.status).toEqual(404);
-        expect(resp.body).toEqual({
-          error: 'Not Found',
-          message: 'Module with moduleId 777 is not supported',
-          statusCode: 404,
+          expect(resp.status).toEqual(404);
+          expect(resp.body).toEqual({
+            error: 'Not Found',
+            message: 'Module with moduleId 777 is not supported',
+            statusCode: 404,
+          });
+        });
+
+        it('should return 400 error if module_id is not a contract address or number', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            '/v1/modules/sjdnsjkfsjkbfsjdfbdjfb/validators/validator-exits-to-prepare/1',
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if module_id is not set', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/modules//validators/validator-exits-to-prepare/1');
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if module_id is negative value', async () => {
+          const resp = await request(app.getHttpServer()).get('/v1/modules/-1/validators/validator-exits-to-prepare/1');
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('Should return 400 error if module_id zero address', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${AddressZero}/validators/validator-exits-to-prepare/1`,
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id cannot be the zero address'],
+            statusCode: 400,
+          });
         });
       });
 
-      it("Should return empty list if operator doesn't exist", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(
-          `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/777`,
-        );
+      describe('validate operator_id', () => {
+        it("Should return empty list if operator doesn't exist", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/777`,
+          );
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
+        });
+
+        it('Should return 400 error if operator was not set', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/`,
+          );
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining([
+              'operator_id should not be null or undefined',
+              'operator_id must not be less than 0',
+              'operator_id must be an integer number',
+            ]),
+          );
+        });
+
+        it('should return 400 error if operator_id is not a number', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/sfsfsf`,
+          );
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must not be less than 0', 'operator_id must be an integer number'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if operator_id is negative value', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/-1`,
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must not be less than 0'],
+            statusCode: 400,
+          });
+        });
+
+        it('Should return 400 error if operator_id is a float', async () => {
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/validator-exits-to-prepare/1.2`)
+            .query({ operatorIndex: 1.5 });
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must be an integer number'],
+            statusCode: 400,
+          });
         });
       });
     });
@@ -390,145 +511,161 @@ describe('SRModulesValidatorsController (e2e)', () => {
         await cleanDB();
       });
 
-      it("Should return 10% validators by default for 'dvt' module when 'operator' is set to 'one'", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(
-          `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`,
-        );
+      describe('percent and amount validation', () => {
+        it("Should return 10% validators by default for 'dvt' module when 'operator' is set to 'one'", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`,
+          );
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(1);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages10percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(1);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages10percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it("Should return 100% validators for 'dvt' module when 'operator' is set to 'one'", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: 100 });
+        it("Should return 100% validators for 'dvt' module when 'operator' is set to 'one'", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: 100 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it("Should prioritize 'percent' over 'max_amount' when both are provided in the query", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: 20, max_amount: 5 });
+        it("Should prioritize 'percent' over 'max_amount' when both are provided in the query", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: 20, max_amount: 5 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(2);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages20percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(2);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages20percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 5 validators when max_amount is 5', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ max_amount: 5 });
+        it('Should return 5 validators when max_amount is 5', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ max_amount: 5 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(5);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages5maxAmount));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(5);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages5maxAmount));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 100% validators when max_amount exceeds the total validator amount', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ max_amount: 100 });
+        it('Should return 100% validators when max_amount exceeds the total validator amount', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ max_amount: 100 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 100% validators when percent exceeds the total validator amount', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: 200 });
+        it('Should return 100% validators when percent exceeds the total validator amount', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: 200 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(10);
-        expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(10);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages100percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return empty list of validators when percent equal to 0', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: 0 });
+        it('Should return empty list of validators when percent equal to 0', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: 0 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return empty list of validators when max_amount equal to 0', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: 0 });
+        it('Should return empty list of validators when max_amount equal to 0', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: 0 });
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data.length).toEqual(0);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(0);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
         });
-      });
 
-      it('Should return 400 error if percent or max_amount are negative', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ percent: -1, max_amount: -1 });
+        it('Should return 400 error if percent or max_amount are negative', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ percent: -1, max_amount: -1 });
 
-        expect(resp.status).toEqual(400);
-        expect(resp.body.message).toEqual(
-          expect.arrayContaining(['max_amount must not be less than 0', 'percent must not be less than 0']),
-        );
-      });
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining(['max_amount must not be less than 0', 'percent must not be less than 0']),
+          );
+        });
 
-      it('Should return 400 error if percent or max_amount is not number', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer())
-          .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
-          .query({ max_amount: 'dfsdfds', percent: 'sdsdfsf' });
+        it('Should return 400 error if percent or max_amount is not number', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ max_amount: 'dfsdfds', percent: 'sdsdfsf' });
 
-        expect(resp.status).toEqual(400);
-        expect(resp.body.message).toEqual(
-          expect.arrayContaining([
-            'max_amount must not be less than 0',
-            'max_amount must be an integer number',
-            'percent must not be less than 0',
-            'percent must be an integer number',
-          ]),
-        );
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining([
+              'max_amount must not be less than 0',
+              'max_amount must be an integer number',
+              'percent must not be less than 0',
+              'percent must be an integer number',
+            ]),
+          );
+        });
+
+        it('Should return 10% validators by default if percent or max_amount are not set', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1`)
+            .query({ max_amount: '', percent: '' });
+
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data.length).toEqual(1);
+          expect(resp.body.data).toEqual(expect.arrayContaining(dvtOpOneRespExitMessages10percent));
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
+        });
       });
 
       it("Should return a 500 error if 'el_meta' is older than 'cl_meta'", async () => {
@@ -546,30 +683,136 @@ describe('SRModulesValidatorsController (e2e)', () => {
         });
       });
 
-      it('Should return a 404 error if the requested module does not exist', async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(
-          `/v1/modules/777/validators/generate-unsigned-exit-messages/1`,
-        );
+      describe('validate module id', () => {
+        it('Should return a 404 error if the requested module does not exist', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/777/validators/generate-unsigned-exit-messages/1`,
+          );
 
-        expect(resp.status).toEqual(404);
-        expect(resp.body).toEqual({
-          error: 'Not Found',
-          message: 'Module with moduleId 777 is not supported',
-          statusCode: 404,
+          expect(resp.status).toEqual(404);
+          expect(resp.body).toEqual({
+            error: 'Not Found',
+            message: 'Module with moduleId 777 is not supported',
+            statusCode: 404,
+          });
+        });
+
+        it('should return 400 error if module_id is not a contract address or number', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            '/v1/modules/sjdnsjkfsjkbfsjdfbdjfb/validators/generate-unsigned-exit-messages/1',
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if module_id is not set', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            '/v1/modules//validators/generate-unsigned-exit-messages/1',
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if module_id is negative value', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            '/v1/modules/-1/validators/generate-unsigned-exit-messages/1',
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id must be a contract address or numeric value'],
+            statusCode: 400,
+          });
+        });
+
+        it('Should return 400 error if module_id zero address', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${AddressZero}/validators/generate-unsigned-exit-messages/1`,
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['module_id cannot be the zero address'],
+            statusCode: 400,
+          });
         });
       });
 
-      it("Should return empty list if operator doesn't exist", async () => {
-        await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
-        const resp = await request(app.getHttpServer()).get(
-          `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/777`,
-        );
+      describe('validate operator id', () => {
+        it("Should return empty list if operator doesn't exist", async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/777`,
+          );
 
-        expect(resp.status).toEqual(200);
-        expect(resp.body.data).toEqual([]);
-        expect(resp.body.meta).toEqual({
-          clBlockSnapshot: consensusMetaResp,
+          expect(resp.status).toEqual(200);
+          expect(resp.body.data).toEqual([]);
+          expect(resp.body.meta).toEqual({
+            clBlockSnapshot: consensusMetaResp,
+          });
+        });
+
+        it('Should return 400 error if operator was not set', async () => {
+          await elMetaStorageService.update({ ...elMeta, number: consensusMetaResp.blockNumber });
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/`,
+          );
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body.message).toEqual(
+            expect.arrayContaining([
+              'operator_id should not be null or undefined',
+              'operator_id must not be less than 0',
+              'operator_id must be an integer number',
+            ]),
+          );
+        });
+
+        it('should return 400 error if operator_id is not a number', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/sfsfsf`,
+          );
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must not be less than 0', 'operator_id must be an integer number'],
+            statusCode: 400,
+          });
+        });
+
+        it('should return 400 error if operator_id is negative value', async () => {
+          const resp = await request(app.getHttpServer()).get(
+            `/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/-1`,
+          );
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must not be less than 0'],
+            statusCode: 400,
+          });
+        });
+
+        it('Should return 400 error if operator_id is a float', async () => {
+          const resp = await request(app.getHttpServer())
+            .get(`/v1/modules/${dvtModule.moduleId}/validators/generate-unsigned-exit-messages/1.2`)
+            .query({ operatorIndex: 1.5 });
+
+          expect(resp.status).toEqual(400);
+          expect(resp.body).toEqual({
+            error: 'Bad Request',
+            message: ['operator_id must be an integer number'],
+            statusCode: 400,
+          });
         });
       });
     });

--- a/src/http/sr-modules/sr-modules.e2e-spec.ts
+++ b/src/http/sr-modules/sr-modules.e2e-spec.ts
@@ -20,6 +20,7 @@ import { elMeta } from '../el-meta.fixture';
 import { curatedModule, dvtModule } from '../db.fixtures';
 import { DatabaseE2ETestingModule } from 'app';
 import { CSMKeyRegistryService } from 'common/registry-csm';
+import { AddressZero } from '@ethersproject/constants';
 
 describe('SRModulesController (e2e)', () => {
   let app: INestApplication;
@@ -215,6 +216,26 @@ describe('SRModulesController (e2e)', () => {
         expect(resp.body).toEqual({
           error: 'Bad Request',
           message: ['module_id must be a contract address or numeric value'],
+          statusCode: 400,
+        });
+      });
+
+      it('Should return 400 error if module_id is not set', async () => {
+        const resp = await request(app.getHttpServer()).get('/v1/modules/');
+        expect(resp.status).toEqual(400);
+        expect(resp.body).toEqual({
+          error: 'Bad Request',
+          message: ['module_id must be a contract address or numeric value'],
+          statusCode: 400,
+        });
+      });
+
+      it('Should return 400 error if module_id is not set', async () => {
+        const resp = await request(app.getHttpServer()).get(`/v1/modules/${AddressZero}`);
+        expect(resp.status).toEqual(400);
+        expect(resp.body).toEqual({
+          error: 'Bad Request',
+          message: ['module_id cannot be the zero address'],
           statusCode: 400,
         });
       });

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,8 +9,6 @@ import { ConfigService } from './common/config';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from './app';
 import { MikroORM } from '@mikro-orm/core';
 
-// need also filter query params
-// forbidUnknownValues: true
 export const validationOpt = { transform: true };
 
 async function bootstrap() {

--- a/src/staking-router-modules/contracts/lido-locator/lido-locator.service.ts
+++ b/src/staking-router-modules/contracts/lido-locator/lido-locator.service.ts
@@ -15,11 +15,13 @@ export class LidoLocatorService {
   async getStakingRouter(blockTag: BlockTag) {
     const locatorENVAddress = this.config.get('LIDO_LOCATOR_DEVNET_ADDRESS');
 
-    this.loggerService.log('Contract locator address', { contract: this.contract.address, env: locatorENVAddress });
-
     if (locatorENVAddress) {
+      this.loggerService.log('Contract locator address', { contract: this.contract.address, env: locatorENVAddress });
+
       return await this.contract.attach(locatorENVAddress).stakingRouter({ blockTag } as any);
     }
+
+    this.loggerService.log('Contract locator address', { contract: this.contract.address });
 
     return await this.contract.stakingRouter({ blockTag } as any);
   }


### PR DESCRIPTION
In issue was reported problem of transformation values in endpoints https://github.com/lidofinance/lido-keys-api/issues/286 

Errors in transformation:

  - `KeyQuery` DTO, used for endpoint queries:
      - If `operatorIndex` set as empty parameter it will be cast to 0 value
         Example that will show error result: 
           `/v1/keys?operatorIndex=&moduleAddresses=0xaE7B191A31f627b4eB1d4DaC64eaB9976995b433`
           
           It will return keys for 0 operator, instead we want to ignore this filter  and return all keys
      - If `used` set as empty string it will throw error and return 400 validation error
           instead we want to ignore this filter 
     
           
  - OperatorId DTO, used for parameters of requests
     for example 
   
Changes:

Errors:   

  - fixed KeyQuery to 
       - not convert '' values to 0 for operatorIndex  query
       - not throw error for  '' values for used query
   - fixed OperatorId to
       - not convert '' values for operator_id to 0 
       - throw 400 error if set '' instead of operator number

Improvements:
  - Check `moduleAddresses` in endpoints queries to be ethereum addresses;
  - for moduleIdPipe forbid zero addresses
  - Add decorator IsPubkey that will check that string is  correct hex 48 bytes string
  - for endpoint /v1/keys/{key} return 400 error if key is not hex 48 bytes string

Provided tests for all endpoints