### PR TITLE
Skip cache for routes with streaming

### DIFF
--- a/src/common/decorators/skipCache.ts
+++ b/src/common/decorators/skipCache.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const SKIP_CACHE_KEY = 'skipCache';
+export const SkipCache = () => SetMetadata(SKIP_CACHE_KEY, true);

--- a/src/http/common/cache/cache.service.ts
+++ b/src/http/common/cache/cache.service.ts
@@ -1,0 +1,31 @@
+import { CacheInterceptor, CACHE_KEY_METADATA } from '@nestjs/cache-manager';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { SKIP_CACHE_KEY } from 'common/decorators/skipCache';
+
+@Injectable()
+export class CustomCacheInterceptor extends CacheInterceptor {
+  trackBy(context: ExecutionContext): string | undefined {
+    const shouldSkip = this.reflector.getAllAndOverride<boolean>(SKIP_CACHE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (shouldSkip) {
+      return undefined;
+    }
+
+    const httpAdapter = this.httpAdapterHost.httpAdapter;
+    const isHttpApp = httpAdapter && !!httpAdapter.getRequestMethod;
+    const cacheMetadata = this.reflector.get(CACHE_KEY_METADATA, context.getHandler());
+
+    if (!isHttpApp || cacheMetadata) {
+      return cacheMetadata;
+    }
+
+    const request = context.getArgByIndex(0);
+    if (!this.isRequestCacheable(context)) {
+      return undefined;
+    }
+    return httpAdapter.getRequestUrl(request);
+  }
+}

--- a/src/http/http.module.ts
+++ b/src/http/http.module.ts
@@ -1,6 +1,5 @@
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { MiddlewareConsumer, Module } from '@nestjs/common';
-import { CacheInterceptor } from '@nestjs/cache-manager';
 
 import { HEALTH_URL } from '../common/health';
 import { METRICS_URL } from '../common/prometheus';
@@ -16,6 +15,7 @@ import { SRModulesKeysModule } from './sr-modules-keys';
 import { SRModulesOperatorsModule } from './sr-modules-operators';
 import { SRModulesOperatorsKeysModule } from './sr-modules-operators-keys';
 import { StatusModule } from './status';
+import { CustomCacheInterceptor } from './common/cache/cache.service';
 
 @Module({
   imports: [
@@ -31,7 +31,7 @@ import { StatusModule } from './status';
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerBehindProxyGuard },
-    { provide: APP_INTERCEPTOR, useClass: CacheInterceptor },
+    { provide: APP_INTERCEPTOR, useClass: CustomCacheInterceptor },
   ],
 })
 export class HTTPModule {

--- a/src/http/keys/keys.controller.ts
+++ b/src/http/keys/keys.controller.ts
@@ -25,6 +25,7 @@ import * as JSONStream from 'jsonstream';
 import { EntityManager } from '@mikro-orm/knex';
 import { IsolationLevel } from '@mikro-orm/core';
 import { Pubkey } from 'http/common/entities/pubkey';
+import { SkipCache } from 'common/decorators/skipCache';
 
 @Controller('keys')
 @ApiTags('keys')
@@ -37,6 +38,7 @@ export class KeysController {
 
   @Version('1')
   @Get()
+  @SkipCache()
   @ApiResponse({
     status: 425,
     description: "Meta is null, maybe data hasn't been written in db yet",

--- a/src/http/sr-modules-keys/sr-modules-keys.controller.ts
+++ b/src/http/sr-modules-keys/sr-modules-keys.controller.ts
@@ -25,6 +25,7 @@ import { EntityManager } from '@mikro-orm/knex';
 import * as JSONStream from 'jsonstream';
 import type { FastifyReply } from 'fastify';
 import { ModuleIdPipe } from '../common/pipeline/module-id-pipe';
+import { SkipCache } from 'common/decorators/skipCache';
 
 @Controller('modules')
 @ApiTags('sr-module-keys')
@@ -55,6 +56,7 @@ export class SRModulesKeysController {
 
   @Version('1')
   @ApiOperation({ summary: 'Staking router module keys' })
+  @SkipCache()
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'List of all modules supported in API',

--- a/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
+++ b/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
@@ -21,6 +21,7 @@ import * as JSONStream from 'jsonstream';
 import type { FastifyReply } from 'fastify';
 import { ModuleIdPipe } from 'http/common/pipeline/module-id-pipe';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { SkipCache } from 'common/decorators/skipCache';
 
 @Controller('/modules')
 @ApiTags('operators-keys')
@@ -32,6 +33,7 @@ export class SRModulesOperatorsKeysController {
   ) {}
 
   @Version('1')
+  @SkipCache()
   @ApiOperation({ summary: 'Staking router module operators' })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -102,6 +104,7 @@ export class SRModulesOperatorsKeysController {
   }
 
   @Version('2')
+  @SkipCache()
   @ApiOperation({ summary: 'Comprehensive stream for staking router modules, operators and their keys' })
   @ApiResponse({
     status: HttpStatus.OK,


### PR DESCRIPTION
After cache-manager update found errors in log like
```
 [error] An error has occurred when inserting "key: /v1/keys", "value: undefined"
```

error doesn't influence accessibility of service

added SkipCache decorator to disable caching for endpoints with streaming
