### PR TITLE
fix: move rimraf to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "pg-query-stream": "^4.5.3",
     "prom-client": "^14.2.0",
     "reflect-metadata": "^0.1.13",
-    "rimraf": "^3.0.2",
     "rxjs": "^7.5.2",
     "typechain": "^8.0.0"
   },
@@ -97,6 +96,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "jest": "^29.7.0",
     "prettier": "^2.5.1",
+    "rimraf": "^3.0.2",
     "supertest": "^6.2.1",
     "ts-jest": "^29.4.0",
     "ts-loader": "^9.2.6",


### PR DESCRIPTION
As the `rimraf` lib is used only in the `postinstall` and `prebuild` package.json scripts, it doesn't make sense to keep it in the production build.