### PR TITLE
fix: improve errors logging

### DIFF
--- a/src/common/execution-provider/execution-provider.module.ts
+++ b/src/common/execution-provider/execution-provider.module.ts
@@ -1,4 +1,5 @@
-import { Global, Module } from '@nestjs/common';
+import { Global, LoggerService, Module } from '@nestjs/common';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { FallbackProviderModule } from '@lido-nestjs/execution';
 import { PrometheusService } from '../prometheus';
 import { ConfigService } from '../config';
@@ -8,7 +9,7 @@ import { ExecutionProviderService } from './execution-provider.service';
 @Module({
   imports: [
     FallbackProviderModule.forRootAsync({
-      async useFactory(configService: ConfigService, prometheusService: PrometheusService) {
+      async useFactory(configService: ConfigService, logger: LoggerService, prometheusService: PrometheusService) {
         return {
           urls: configService.get('PROVIDERS_URLS'),
           network: configService.get('CHAIN_ID'),
@@ -27,6 +28,8 @@ import { ExecutionProviderService } from './execution-provider.service';
                 endTimer({ result: 'success' });
                 return result;
               } catch (error) {
+                logger.error('Execution provider error');
+                logger.error(error);
                 endTimer({ result: 'error' });
                 throw error;
               } finally {
@@ -36,7 +39,7 @@ import { ExecutionProviderService } from './execution-provider.service';
           ],
         };
       },
-      inject: [ConfigService, PrometheusService],
+      inject: [ConfigService, LOGGER_PROVIDER, PrometheusService],
     }),
   ],
   providers: [ExecutionProviderService],

--- a/src/common/registry-csm/fetch/operator.fetch.ts
+++ b/src/common/registry-csm/fetch/operator.fetch.ts
@@ -27,10 +27,9 @@ export class RegistryOperatorFetchService {
   ): Promise<string> {
     const type = this.moduleTypeRegistry.get(moduleAddress);
     if (!type) {
-      this.logger.error('Module type is not warmed up in ModuleTypeRegistry', {
-        moduleAddress,
-        operatorIndex,
-      });
+      this.logger.error(
+        `Type for module ${moduleAddress} is not warmed up in ModuleTypeRegistry. Requested operator index: ${operatorIndex}.`,
+      );
       throw new Error(
         `ModuleTypeRegistry has no entry for ${moduleAddress}. ` +
           `It must be populated before calling operator fetch.`,
@@ -39,11 +38,11 @@ export class RegistryOperatorFetchService {
 
     const resolver = this.resolvers[type];
     if (!resolver) {
-      this.logger.error('No operator name resolver configured for module type', {
-        moduleAddress,
-        moduleType: type,
-        supportedTypes: Object.keys(this.resolvers),
-      });
+      this.logger.error(
+        `No operator name resolver configured for type ${type} of module ${moduleAddress}. Supported types: ${Object.keys(
+          this.resolvers,
+        ).join(', ')}.`,
+      );
       throw new Error(
         `No operator name resolver for module type "${type}" at ${moduleAddress}. ` +
           `CSM operator fetch supports only COMMUNITY_ONCHAIN_V1 and CURATED_ONCHAIN_V2.`,

--- a/src/common/registry-csm/fetch/registry-fetch.module.ts
+++ b/src/common/registry-csm/fetch/registry-fetch.module.ts
@@ -25,10 +25,7 @@ import {
     MetaRegistryNameResolver,
     {
       provide: OPERATOR_NAME_RESOLVERS_TOKEN,
-      useFactory: (
-        csm: CsmStaticNameResolver,
-        meta: MetaRegistryNameResolver,
-      ): OperatorNameResolversConfig => ({
+      useFactory: (csm: CsmStaticNameResolver, meta: MetaRegistryNameResolver): OperatorNameResolversConfig => ({
         // Keys match values of STAKING_MODULE_TYPE enum in staking-router-modules/constants.ts.
         // String literals are used here to avoid cross-layer import of the enum into common/.
         'community-onchain-v1': csm,

--- a/src/common/registry/test/fetch/operator.fetch.spec.ts
+++ b/src/common/registry/test/fetch/operator.fetch.spec.ts
@@ -28,7 +28,10 @@ describe('Operators', () => {
   const respondByMethod = (data: string, address: string) => {
     const selector = data.slice(0, 10);
     if (selector === getNodeOperatorSelector) {
-      return registryIface.encodeFunctionResult('getNodeOperator', operatorFields({ ...operator, moduleAddress: address }));
+      return registryIface.encodeFunctionResult(
+        'getNodeOperator',
+        operatorFields({ ...operator, moduleAddress: address }),
+      );
     }
     if (selector === getNodeOperatorSummarySelector) {
       return registryIface.encodeFunctionResult('getNodeOperatorSummary', operatorSummaryFields(operatorSummary));

--- a/src/http/sr-modules-keys/sr-modules-keys.controller.ts
+++ b/src/http/sr-modules-keys/sr-modules-keys.controller.ts
@@ -107,7 +107,8 @@ export class SRModulesKeysController {
           jsonStream.end();
         } catch (streamError) {
           // Handle the error during streaming.
-          this.logger.error('module-keys streaming error', streamError);
+          this.logger.error('module-keys streaming error');
+          this.logger.error(streamError);
           // destroy method closes the stream without ']' and corrupt the result
           // https://github.com/dominictarr/through/blob/master/index.js#L78
           jsonStream.destroy();

--- a/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
+++ b/src/http/sr-modules-operators-keys/sr-modules-operators-keys.controller.ts
@@ -93,7 +93,8 @@ export class SRModulesOperatorsKeysController {
           jsonStream.end();
         } catch (streamError) {
           // Handle the error during streaming.
-          this.logger.error('operators-keys streaming error', streamError);
+          this.logger.error('operators-keys streaming error');
+          this.logger.error(streamError);
           // destroy method closes the stream without ']' and corrupt the result
           // https://github.com/dominictarr/through/blob/master/index.js#L78
           jsonStream.destroy();
@@ -134,13 +135,8 @@ export class SRModulesOperatorsKeysController {
 
           jsonStream.end();
         } catch (error) {
-          if (error instanceof Error) {
-            const message = error.message;
-            const stack = error.stack;
-            this.logger.error(`modules-operators-keys error: ${message}`, stack);
-          } else {
-            this.logger.error('modules-operators-keys unknown error');
-          }
+          this.logger.error('modules-operators-keys error');
+          this.logger.error(error);
 
           jsonStream.destroy();
         }

--- a/src/jobs/keys-update/keys-update.service.ts
+++ b/src/jobs/keys-update/keys-update.service.ts
@@ -83,7 +83,9 @@ export class KeysUpdateService {
 
     this.updateDeadlineTimer = setTimeout(async () => {
       const error = new KeyOutdatedError(
-        `There were no keys update more than ${this.UPDATE_KEYS_TIMEOUT_MS / (1000 * 60)} minutes`,
+        `There were no keys update more than ${
+          this.UPDATE_KEYS_TIMEOUT_MS / (1000 * 60)
+        } minutes. Last processed block: ${this.lastBlockNumber}.`,
         this.lastBlockNumber,
       );
       this.logger.error(error);

--- a/src/jobs/validators-update/validators-update.service.ts
+++ b/src/jobs/validators-update/validators-update.service.ts
@@ -77,7 +77,9 @@ export class ValidatorsUpdateService {
 
     this.updateDeadlineTimer = setTimeout(async () => {
       const error = new ValidatorsOutdatedError(
-        `There were no validators update more than ${this.UPDATE_VALIDATORS_TIMEOUT_MS / (60 * 1000)} minutes`,
+        `There were no validators update more than ${
+          this.UPDATE_VALIDATORS_TIMEOUT_MS / (60 * 1000)
+        } minutes. Last processed block: ${this.lastBlockNumber}.`,
         this.lastBlockNumber,
       );
       this.logger.error(error);


### PR DESCRIPTION
Log unhandled execution provider errors that don't cause the app jobs' termination.

Also, improved logging errors. Previously, constructions like `logger.error('Some error', { extra:
'object' })` or `logger.error('Some error', errorObject)` led to incorrect strings in logs.

For example, the construction
```
this.logger.error('No operator name resolver configured for module type', {
   moduleAddress,
   moduleType: type,
   supportedTypes: Object.keys(this.resolvers),
});
```
appeared in logs as
```
No operator name resolver configured for module type [object Object]
```
in "simple" logging mode, and as
```
{"level":"error","message":"No operator name resolver configured for module type","stack":[{"moduleAddress":"0xda7de2ecddfccc6c3af10108db212acbbf9ea8
3f","moduleType":"community-onchain-v1","supportedTypes":["community-onchain-v1","curated-onchain-v2"]}]}
```
in "json" logging mode (which is also is not 100% correct, because passed object is not a "stack").

It looks better to insert all necessary params as inline values to the error string and pass it to the logger.

The construction
```
const err = new Error(`No operator name resolver`);
this.logger.error('Invalid type', err);
```
appeared in logs as
```
Invalid type [object Object]
```
in "simple" logging mode, and as
```
{"level":"error","message":"Invalid type","stack":[{"message":"No operator name resolver"}]}
```
in "json" logging mode.

To prevent this incorrect display, now full error objects are logged as `logger.error(error)`.