### PR TITLE
feat: expose lido-keys-api executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Lido Node Operators keys service",
   "author": "Lido team",
   "private": true,
+  "bin": {
+    "lido-keys-api": "dist/src/main.js"
+  },
+  "files": [
+    "dist"
+  ],
   "license": "MIT",
   "mikro-orm": {
     "useTsNode": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import * as Sentry from '@sentry/node';


### PR DESCRIPTION
- add a package bin entry for lido-keys-api
- include the dist directory in packed releases
- add a Node.js shebang to the entry point

This would simplify installation on Nix with `yarnInstallHook` and other tools expecting `bin`:
https://nixos.org/manual/nixpkgs/unstable/#javascript-yarn-v1