### PR TITLE
Run under an orchestrator: image build, prompt shutdown, credential rotation

### DIFF
--- a/.github/workflows/ci-dev-k8s.yml
+++ b/.github/workflows/ci-dev-k8s.yml
@@ -1,0 +1,35 @@
+name: Build and push lido-keys-api to dev
+
+run-name: Build and push lido-keys-api:dev to dev
+
+# Builds the mutable `dev` image tag through the shared reusable build workflow, so action
+# pins, buildx setup and cache behaviour are maintained in one place.
+#
+# This runs alongside ci-dev.yml and does not replace it: both delivery paths are active
+# until the cutover.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - develop
+    # paths-ignore rather than an allowlist of paths: an allowlist has to be extended every
+    # time a new file is baked into the image, and a forgotten entry produces a stale image
+    # with a green pipeline rather than a failure.
+    paths-ignore:
+      - '.github/**'
+      - 'test/**'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    uses: lidofinance/actions/.github/workflows/k8s-build-push-harbor.yml@c7b5b6c5d8013046347d728d748fa741eb214e28
+    with:
+      tag: dev
+      registry: registry.dev.k8s-dev.org
+      registry_username: ${{ vars.REGISTRY_USERNAME }}
+      image: team-oracles/lido-keys-api
+      environment: harbor_dev_release
+    secrets:
+      registry_token: ${{ secrets.HARBOR_DEV_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,33 @@ FROM node:20.20-alpine3.23 AS building
 
 WORKDIR /app
 
+# Manifests before source, so a source change does not bust the dependency layer
 COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --non-interactive && yarn cache clean
+
 COPY ./tsconfig*.json ./
 COPY ./src ./src
 
-RUN yarn install --frozen-lockfile --non-interactive && yarn cache clean && yarn typechain
-RUN yarn build
+RUN yarn typechain && yarn build
+
+# Production-only dependency tree for the runtime stage
+FROM node:20.20-alpine3.23 AS proddeps
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile --non-interactive --production && yarn cache clean
 
 FROM node:20.20-alpine3.23
 
 WORKDIR /app
 
 COPY --from=building /app/dist ./dist
-COPY --from=building /app/node_modules ./node_modules
+COPY --from=proddeps /app/node_modules ./node_modules
 COPY ./package.json ./
+
+# Rewritten by the shared build pipeline in the checkout; read at startup for build_info labels
+COPY build-info.json ./
 
 USER node
 

--- a/build-info.json
+++ b/build-info.json
@@ -1,0 +1,4 @@
+{
+  "branch": "REPLACE_WITH_BRANCH",
+  "commit": "REPLACE_WITH_COMMIT"
+}

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,12 @@
 # App
 PORT=3000
 
+# JSON file the configuration is read from, if it exists. Values in it win over everything below,
+# and a change to it makes the process exit so the new ones are read at start. No file at the path
+# means every setting comes from this environment, which is the default.
+# SECRETS_FILE_PATH=/vault/secrets/config
+# SECRETS_POLL_INTERVAL_IN_SECONDS=10
+
 # CORS
 CORS_WHITELIST_REGEXP=^https?://(?:.+?\.)?(?:lido|testnet|mainnet)\.fi$
 

--- a/src/app/app.service.ts
+++ b/src/app/app.service.ts
@@ -5,6 +5,7 @@ import { ConsensusProviderService } from '../common/consensus-provider';
 import { ConfigService } from '../common/config';
 import { PrometheusService } from '../common/prometheus';
 import { APP_NAME, APP_VERSION } from './app.constants';
+import { readBuildInfo } from './build-info';
 
 @Injectable()
 export class AppService implements OnModuleInit {
@@ -25,8 +26,9 @@ export class AppService implements OnModuleInit {
     const version = APP_VERSION;
     const name = APP_NAME;
     const network = await this.executionProviderService.getNetworkName();
-    this.prometheusService.buildInfo.labels({ env, name, version, network }).inc();
-    this.logger.log('Init app', { env, name, version });
+    const { branch, commit } = readBuildInfo();
+    this.prometheusService.buildInfo.labels({ env, name, version, network, commit, branch }).inc();
+    this.logger.log('Init app', { env, name, version, commit, branch });
   }
 
   /**

--- a/src/app/build-info.ts
+++ b/src/app/build-info.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+
+export interface BuildInfo {
+  readonly branch: string;
+  readonly commit: string;
+}
+
+// The shared build pipeline rewrites build-info.json in the checkout before the image is built;
+// the committed placeholder keeps local and dev builds working without it.
+export const readBuildInfo = (path = 'build-info.json'): BuildInfo => {
+  let parsed: Partial<BuildInfo>;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<BuildInfo>;
+  } catch {
+    parsed = {};
+  }
+  return {
+    branch: typeof parsed.branch === 'string' ? parsed.branch : 'unknown',
+    commit: typeof parsed.commit === 'string' ? parsed.commit : 'unknown',
+  };
+};

--- a/src/common/config/config.service.ts
+++ b/src/common/config/config.service.ts
@@ -1,15 +1,37 @@
 import { ConfigService as ConfigServiceSource } from '@nestjs/config';
 import { EnvironmentVariables } from './env.validation';
 import { readFileSync } from 'fs';
+import { SECRETS_IN_FORCE } from '../secrets/bootstrap-env';
 
 export class ConfigService extends ConfigServiceSource<EnvironmentVariables> {
   /**
    * List of env variables that should be hidden
    */
   public get secrets(): string[] {
-    return [this.get('SENTRY_DSN') ?? '', ...this.get('CL_API_URLS'), ...this.get('PROVIDERS_URLS')]
+    return [
+      this.get('SENTRY_DSN') ?? '',
+      ...this.get('CL_API_URLS'),
+      ...this.get('PROVIDERS_URLS'),
+      this.dbPasswordForMasking(),
+      // Whatever the secrets file carried: the key names are not known ahead of time, and
+      // every value it holds is a secret by definition.
+      ...Object.values(SECRETS_IN_FORCE),
+    ]
       .filter((v) => v)
       .map((v) => String(v));
+  }
+
+  // The DB_PASSWORD getter exits the process when neither env is set; masking must never.
+  private dbPasswordForMasking(): string {
+    const direct = super.get('DB_PASSWORD', { infer: true });
+    if (direct) return String(direct);
+    const filePath = super.get('DB_PASSWORD_FILE', { infer: true });
+    if (!filePath) return '';
+    try {
+      return this.readEnvFromFile(filePath, 'DB_PASSWORD_FILE');
+    } catch {
+      return '';
+    }
   }
 
   public get<T extends keyof EnvironmentVariables>(key: T): EnvironmentVariables[T] {

--- a/src/common/config/env.validation.spec.ts
+++ b/src/common/config/env.validation.spec.ts
@@ -1,4 +1,4 @@
-import { validate } from './env.validation';
+import { maskSecretsInValidationOutput, validate } from './env.validation';
 import { EnvironmentVariables } from './env.validation';
 
 function omit<T extends Record<K, any>, K extends string>(obj: T, ...keys: K[]): Omit<T, K> {
@@ -844,6 +844,41 @@ describe('Environment validation', () => {
     it('should skip CL_API_URLS validation if VALIDATOR_REGISTRY_ENABLE is false', () => {
       expect(() => runValidation(required_configs)).not.toThrow();
       expect(runValidation(required_configs).VALIDATOR_REGISTRY_ENABLE).toBe(false);
+    });
+  });
+
+  describe('maskSecretsInValidationOutput', () => {
+    const config = {
+      // nosemgrep: semgrep.detected-generic-secrets -- test-only non-secret value
+      DB_PASSWORD: 'hunter2hunter2',
+      SENTRY_DSN: 'https://abc123@sentry.example.org/42',
+      PROVIDERS_URLS: 'https://el-a.example.org/keyA, https://el-b.example.org/keyB',
+      CL_API_URLS: 'https://cl.example.org/keyC',
+    };
+
+    it('masks the DB password and Sentry DSN', () => {
+      const masked = maskSecretsInValidationOutput(
+        'pw hunter2hunter2, dsn https://abc123@sentry.example.org/42',
+        config,
+      );
+      expect(masked).toBe('pw <removed>, dsn <removed>');
+    });
+
+    it('masks every entry of the provider URL lists', () => {
+      const masked = maskSecretsInValidationOutput(
+        'tried https://el-a.example.org/keyA then https://el-b.example.org/keyB then https://cl.example.org/keyC',
+        config,
+      );
+      expect(masked).toBe('tried <removed> then <removed> then <removed>');
+    });
+
+    it('leaves text without secret values untouched', () => {
+      const text = 'property CHAIN_ID has failed the following constraints: isInt';
+      expect(maskSecretsInValidationOutput(text, config)).toBe(text);
+    });
+
+    it('handles absent secret keys', () => {
+      expect(maskSecretsInValidationOutput('nothing to mask', {})).toBe('nothing to mask');
     });
   });
 });

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -14,9 +14,11 @@ import {
   Min,
   ValidateIf,
   validateSync,
+  getMetadataStorage,
 } from 'class-validator';
 import { Environment, LogLevel, LogFormat, Chain } from './interfaces';
 import { NonEmptyArray } from '@lido-nestjs/execution/dist/interfaces/non-empty-array';
+import { SECRETS_IN_FORCE } from '../secrets/bootstrap-env';
 
 const toNumber =
   ({ defaultValue }) =>
@@ -230,6 +232,40 @@ export class EnvironmentVariables {
   LIDO_LOCATOR_DEVNET_ADDRESS = '';
 }
 
+// The logger's replacement token, so masked validation output reads the same as masked logs.
+// The redacting logger itself cannot be used here: validation runs while the config it would
+// be built from is still being parsed.
+const SECRET_REPLACER = '<removed>';
+const SECRET_VALUE_KEYS = ['DB_PASSWORD', 'SENTRY_DSN'];
+const SECRET_URL_LIST_KEYS = ['PROVIDERS_URLS', 'CL_API_URLS'];
+
+export function maskSecretsInValidationOutput(text: string, config: Record<string, unknown>): string {
+  const values = [
+    ...SECRET_VALUE_KEYS.map((key) => config[key]),
+    ...SECRET_URL_LIST_KEYS.flatMap((key) => String(config[key] ?? '').split(',')).map((url) => url.trim()),
+    ...Object.values(SECRETS_IN_FORCE),
+  ]
+    .map((value) => (value == null ? '' : String(value)))
+    .filter((value) => value.length > 0)
+    // Longest first, so a value that contains another one is replaced whole.
+    .sort((a, b) => b.length - a.length);
+
+  return values.reduce((result, value) => result.split(value).join(SECRET_REPLACER), text);
+}
+
+// Decorated fields plus fields with initializers: with target es2017 an uninitialized class
+// field does not exist on a fresh instance, so neither source alone lists every key.
+export function declaredConfigKeys(): string[] {
+  const decorated = getMetadataStorage()
+    .getTargetValidationMetadatas(EnvironmentVariables, EnvironmentVariables.name, true, false)
+    .map((meta) => meta.propertyName);
+  return [...new Set([...decorated, ...Object.getOwnPropertyNames(new EnvironmentVariables())])];
+}
+
+// Exposed for the startup dump: the validated instance carries every effective value,
+// defaults included, which ConfigService has no way to enumerate.
+export let VALIDATED_ENV: Record<string, unknown> | undefined;
+
 export function validate(config: Record<string, unknown>) {
   if (process.env.NODE_ENV == 'test') {
     return config;
@@ -241,9 +277,14 @@ export function validate(config: Record<string, unknown>) {
   const errors = validateSync(validatedConfig, validatorOptions);
 
   if (errors.length > 0) {
-    console.error(errors.toString());
+    console.error(maskSecretsInValidationOutput(errors.toString(), config));
     process.exit(1);
   }
 
+  // Only the declared keys: plainToInstance keeps unknown properties, so the instance itself
+  // carries the entire environment — npm_* variables, tokens of whatever launched the process.
+  VALIDATED_ENV = Object.fromEntries(
+    declaredConfigKeys().map((key) => [key, (validatedConfig as unknown as Record<string, unknown>)[key]]),
+  );
   return validatedConfig;
 }

--- a/src/common/consensus-provider/consensus-fetch.service.ts
+++ b/src/common/consensus-provider/consensus-fetch.service.ts
@@ -2,9 +2,10 @@ import { Inject, Injectable, LoggerService } from '@nestjs/common';
 import { FetchModuleOptions, FetchService, RequestInfo } from '@lido-nestjs/fetch';
 import { MiddlewareService } from '@lido-nestjs/middleware';
 import { AbortController } from 'node-abort-controller';
-import { RequestInit, Response } from 'node-fetch';
+import { Headers, RequestInit, Response } from 'node-fetch';
 import { CONSENSUS_REQUEST_TIMEOUT } from './consensus-provider.constants';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { APP_NAME, APP_VERSION } from '../../app/app.constants';
 
 @Injectable()
 export class ConsensusFetchService extends FetchService {
@@ -17,7 +18,7 @@ export class ConsensusFetchService extends FetchService {
   }
 
   /**
-   * Adds timeout to the source method of fetch service
+   * Adds timeout and User-Agent to the source method of fetch service
    */
   protected async request(url: RequestInfo, init?: RequestInit, attempt = 0) {
     const controller = new AbortController();
@@ -27,6 +28,13 @@ export class ConsensusFetchService extends FetchService {
       controller.abort();
     }, CONSENSUS_REQUEST_TIMEOUT);
 
-    return super.request(url, { ...init, signal }, attempt);
+    // So providers can attribute the traffic. Headers handles every HeadersInit shape a caller
+    // may have passed in init.
+    const headers = new Headers(init?.headers);
+    if (!headers.has('User-Agent')) {
+      headers.set('User-Agent', `${APP_NAME}/${APP_VERSION}`);
+    }
+
+    return super.request(url, { ...init, signal, headers }, attempt);
   }
 }

--- a/src/common/execution-provider/execution-provider.module.ts
+++ b/src/common/execution-provider/execution-provider.module.ts
@@ -1,9 +1,12 @@
 import { Global, LoggerService, Module } from '@nestjs/common';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { FallbackProviderModule } from '@lido-nestjs/execution';
+import { NonEmptyArray } from '@lido-nestjs/execution/dist/interfaces/non-empty-array';
+import { ConnectionInfo } from '@ethersproject/web';
 import { PrometheusService } from '../prometheus';
 import { ConfigService } from '../config';
 import { ExecutionProviderService } from './execution-provider.service';
+import { APP_NAME, APP_VERSION } from '../../app/app.constants';
 
 @Global()
 @Module({
@@ -11,7 +14,12 @@ import { ExecutionProviderService } from './execution-provider.service';
     FallbackProviderModule.forRootAsync({
       async useFactory(configService: ConfigService, logger: LoggerService, prometheusService: PrometheusService) {
         return {
-          urls: configService.get('PROVIDERS_URLS'),
+          // ConnectionInfo instead of plain strings, so providers can attribute the traffic.
+          // The tuple cast is safe: validation rejects an empty PROVIDERS_URLS at startup.
+          urls: configService.get('PROVIDERS_URLS').map((url) => ({
+            url,
+            headers: { 'User-Agent': `${APP_NAME}/${APP_VERSION}` },
+          })) as unknown as NonEmptyArray<ConnectionInfo>,
           network: configService.get('CHAIN_ID'),
           requestPolicy: {
             jsonRpcMaxBatchSize: configService.get('PROVIDER_JSON_RPC_MAX_BATCH_SIZE'),

--- a/src/common/health/health.constants.ts
+++ b/src/common/health/health.constants.ts
@@ -1,1 +1,2 @@
 export const HEALTH_URL = 'health';
+export const HEALTH_READY_URL = 'ready';

--- a/src/common/health/health.controller.ts
+++ b/src/common/health/health.controller.ts
@@ -1,17 +1,55 @@
-import { HealthCheckService, MemoryHealthIndicator, HealthCheck } from '@nestjs/terminus';
+import {
+  HealthCheckService,
+  MemoryHealthIndicator,
+  HealthCheck,
+  HealthCheckError,
+  HealthIndicatorResult,
+} from '@nestjs/terminus';
 import { Controller, Get } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
-import { HEALTH_URL } from './health.constants';
+import { SkipCache } from 'common/decorators/skipCache';
+import { HEALTH_URL, HEALTH_READY_URL } from './health.constants';
 import { HEAP_USED_THRESHOLD } from './constants';
+import { StakingRouterService } from '../../staking-router-modules/staking-router.service';
 
+const READY_DB_TIMEOUT_MS = 1000;
+
+// SkipCache: the global interceptor caches every GET by URL, and a cached 200 kept answering
+// for a probe through a whole database outage — measured before this decorator was here.
 @Controller(HEALTH_URL)
 @ApiExcludeController()
+@SkipCache()
 export class HealthController {
-  constructor(protected health: HealthCheckService, protected memory: MemoryHealthIndicator) {}
+  constructor(
+    protected health: HealthCheckService,
+    protected memory: MemoryHealthIndicator,
+    protected stakingRouter: StakingRouterService,
+  ) {}
 
   @Get()
   @HealthCheck()
   check() {
     return this.health.check([async () => this.memory.checkHeap('memoryHeap', HEAP_USED_THRESHOLD)]);
+  }
+
+  // 503 until the database answers and one meta row exists: without the second half a fresh
+  // instance is Ready in seconds while holding zero keys.
+  @Get(HEALTH_READY_URL)
+  @HealthCheck()
+  ready() {
+    return this.health.check([
+      async (): Promise<HealthIndicatorResult> => {
+        const meta = await Promise.race([
+          this.stakingRouter.getElBlockSnapshot(),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('database read timed out')), READY_DB_TIMEOUT_MS),
+          ),
+        ]);
+        if (!meta) {
+          throw new HealthCheckError('no published meta yet', { registry: { status: 'down' } });
+        }
+        return { registry: { status: 'up' } };
+      },
+    ]);
   }
 }

--- a/src/common/prometheus/prometheus.controller.ts
+++ b/src/common/prometheus/prometheus.controller.ts
@@ -1,7 +1,11 @@
 import { PrometheusController as PrometheusControllerSource } from '@willsoto/nestjs-prometheus';
 import { Controller } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { SkipCache } from 'common/decorators/skipCache';
 
+// SkipCache: a scrape must see the current values, and the same flag routes the no-store
+// Cache-Control header here.
 @Controller()
 @ApiExcludeController()
+@SkipCache()
 export class PrometheusController extends PrometheusControllerSource {}

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -109,4 +109,13 @@ export class PrometheusService {
     name: 'validators_registry_enabled',
     help: 'Validators registry is enabled',
   });
+
+  // A gauge rather than a counter of reloads: the process exits when the file changes, so a
+  // counter would be reset by the restart it is meant to record, and the last increment before an
+  // exit is never scraped. Unprefixed, same name as in the sibling services.
+  public secretsFileMtime = this.getOrCreateMetric('Gauge', {
+    prefix: false,
+    name: 'secrets_file_mtime_seconds',
+    help: 'mtime of the secrets file in force, 0 when the configuration came from the environment',
+  });
 }

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -26,7 +26,7 @@ export class PrometheusService {
     prefix: false,
     name: 'build_info',
     help: 'Build information',
-    labelNames: ['name', 'version', 'env', 'network'],
+    labelNames: ['name', 'version', 'env', 'network', 'commit', 'branch'],
   });
 
   public elRpcRequestDuration = this.getOrCreateMetric('Histogram', {

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -110,9 +110,8 @@ export class PrometheusService {
     help: 'Validators registry is enabled',
   });
 
-  // A gauge rather than a counter of reloads: the process exits when the file changes, so a
-  // counter would be reset by the restart it is meant to record, and the last increment before an
-  // exit is never scraped. Unprefixed, same name as in the sibling services.
+  // A gauge, not a counter: the process exits on a change, so a counter would be reset by the
+  // restart it records.
   public secretsFileMtime = this.getOrCreateMetric('Gauge', {
     prefix: false,
     name: 'secrets_file_mtime_seconds',

--- a/src/common/secrets/bootstrap-env.ts
+++ b/src/common/secrets/bootstrap-env.ts
@@ -1,0 +1,29 @@
+/**
+ * Applies the secrets file to the environment, at import time.
+ *
+ * It has to happen before anything else reads process.env, and several modules do that while they
+ * are still being loaded — the ORM configuration is one — so doing it inside bootstrap() would
+ * already be too late. That is why main.ts imports this module first.
+ *
+ * Anything the runtime itself reads is still out of reach at this point: NODE_OPTIONS is consumed
+ * before a line of this runs, so it belongs in the environment and never in the file.
+ */
+import { DEFAULT_SECRETS_FILE_PATH, loadSecretsIntoEnv } from './secrets';
+
+export const SECRETS_FILE_PATH = process.env.SECRETS_FILE_PATH || DEFAULT_SECRETS_FILE_PATH;
+
+export const SECRETS_POLL_INTERVAL_IN_SECONDS = Number(process.env.SECRETS_POLL_INTERVAL_IN_SECONDS) || undefined;
+
+function load(): Record<string, string> {
+  try {
+    return loadSecretsIntoEnv(SECRETS_FILE_PATH);
+  } catch (error) {
+    // The environment still holds a working configuration, so a bad render costs nothing here.
+    // console, not the logger: the logger is built from the configuration this is producing.
+    console.error(`Secrets file ${SECRETS_FILE_PATH} is unusable, reading configuration from the environment`, error);
+    return {};
+  }
+}
+
+/** What the file put into the environment. Empty means the configuration came from the environment. */
+export const SECRETS_IN_FORCE: Record<string, string> = load();

--- a/src/common/secrets/bootstrap-env.ts
+++ b/src/common/secrets/bootstrap-env.ts
@@ -1,13 +1,5 @@
-/**
- * Applies the secrets file to the environment, at import time.
- *
- * It has to happen before anything else reads process.env, and several modules do that while they
- * are still being loaded — the ORM configuration is one — so doing it inside bootstrap() would
- * already be too late. That is why main.ts imports this module first.
- *
- * Anything the runtime itself reads is still out of reach at this point: NODE_OPTIONS is consumed
- * before a line of this runs, so it belongs in the environment and never in the file.
- */
+// Applies the secrets file at import time: modules read process.env while they load, so doing
+// this inside bootstrap() would already be too late.
 import { DEFAULT_SECRETS_FILE_PATH, loadSecretsIntoEnv } from './secrets';
 
 export const SECRETS_FILE_PATH = process.env.SECRETS_FILE_PATH || DEFAULT_SECRETS_FILE_PATH;
@@ -18,12 +10,11 @@ function load(): Record<string, string> {
   try {
     return loadSecretsIntoEnv(SECRETS_FILE_PATH);
   } catch (error) {
-    // The environment still holds a working configuration, so a bad render costs nothing here.
-    // console, not the logger: the logger is built from the configuration this is producing.
+    // console, not the logger: the logger is built from the configuration this produces.
     console.error(`Secrets file ${SECRETS_FILE_PATH} is unusable, reading configuration from the environment`, error);
     return {};
   }
 }
 
-/** What the file put into the environment. Empty means the configuration came from the environment. */
+/** Empty means the configuration came from the environment. */
 export const SECRETS_IN_FORCE: Record<string, string> = load();

--- a/src/common/secrets/index.ts
+++ b/src/common/secrets/index.ts
@@ -1,0 +1,1 @@
+export * from './secrets';

--- a/src/common/secrets/secrets.spec.ts
+++ b/src/common/secrets/secrets.spec.ts
@@ -1,0 +1,185 @@
+import { mkdtempSync, renameSync, rmSync, utimesSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { changedSecretKeys, loadSecretsIntoEnv, readSecretsFile, secretsFileMtimeMs, SecretsWatcher } from './secrets';
+
+describe('secrets file', () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'kapi-secrets-'));
+    path = join(dir, 'config');
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  // Replaces the file the way the delivering agent does: a temporary file renamed over the path,
+  // which gives it a new inode every time.
+  const render = (contents: string, secondsAhead = 1) => {
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, contents, { mode: 0o600 });
+    renameSync(tmp, path);
+    // Nudged forward explicitly: two renders inside one filesystem tick would be indistinguishable.
+    const when = new Date(Date.now() + secondsAhead * 1000);
+    utimesSync(path, when, when);
+  };
+
+  describe('readSecretsFile', () => {
+    it('reads an absent file as no values rather than as an error', () => {
+      expect(readSecretsFile(join(dir, 'nothing-here'))).toEqual({});
+      expect(readSecretsFile('')).toEqual({});
+    });
+
+    it('stringifies values and drops the ones that rendered to nothing', () => {
+      render('{"PROVIDERS_URLS":"http://el.example.com:8545","STREAM_TIMEOUT":1500,"EMPTY":null}');
+
+      const values = readSecretsFile(path);
+
+      expect(values.PROVIDERS_URLS).toBe('http://el.example.com:8545');
+      // A number in the file must not reach a parser as a number, and a null must not reach one
+      // as the string "null".
+      expect(values.STREAM_TIMEOUT).toBe('1500');
+      expect('EMPTY' in values).toBe(false);
+    });
+
+    it.each([
+      ['not json at all', 'nope'],
+      ['a shell fragment, which is what the previous template rendered', 'export PROVIDERS_URLS="http://el:8545"'],
+      ['a JSON array', '["http://el.example.com:8545"]'],
+      ['JSON null', 'null'],
+      ['an empty file', ''],
+    ])('refuses %s instead of accepting it silently', (_name, contents) => {
+      render(contents);
+      expect(() => readSecretsFile(path)).toThrow();
+    });
+
+    it('reads a file that parses to nothing as no values', () => {
+      render('{}');
+      expect(readSecretsFile(path)).toEqual({});
+    });
+  });
+
+  describe('secretsFileMtimeMs', () => {
+    it('is null when there is nothing at the path', () => {
+      expect(secretsFileMtimeMs(join(dir, 'nothing-here'))).toBeNull();
+    });
+
+    it('moves when the path is renamed over', () => {
+      render('{"A":"1"}');
+      const before = secretsFileMtimeMs(path);
+      render('{"A":"2"}', 2);
+      expect(secretsFileMtimeMs(path)).not.toBe(before);
+    });
+  });
+
+  describe('changedSecretKeys', () => {
+    it('reports a new value, a new key and a key that disappeared', () => {
+      expect(changedSecretKeys({ A: '1', GONE: 'x' }, { A: '2', ADDED: 'y' })).toEqual(['A', 'ADDED', 'GONE']);
+    });
+
+    it('reports nothing for an identical render', () => {
+      expect(changedSecretKeys({ A: '1' }, { A: '1' })).toEqual([]);
+    });
+  });
+
+  describe('loadSecretsIntoEnv', () => {
+    const KEY = 'KAPI_SECRETS_SPEC_URLS';
+
+    afterEach(() => delete process.env[KEY]);
+
+    it('puts the file over the environment', () => {
+      process.env[KEY] = 'http://from-env.example.com:8545';
+      render(`{"${KEY}":"http://from-file.example.com:8545"}`);
+
+      const applied = loadSecretsIntoEnv(path);
+
+      expect(applied).toEqual({ [KEY]: 'http://from-file.example.com:8545' });
+      expect(process.env[KEY]).toBe('http://from-file.example.com:8545');
+    });
+
+    it('leaves the environment alone when there is no file', () => {
+      process.env[KEY] = 'http://from-env.example.com:8545';
+
+      expect(loadSecretsIntoEnv(join(dir, 'nothing-here'))).toEqual({});
+      expect(process.env[KEY]).toBe('http://from-env.example.com:8545');
+    });
+  });
+
+  describe('SecretsWatcher', () => {
+    const watcherOn = (inForce: Record<string, string>) => {
+      const changes: string[][] = [];
+      const errors: Error[] = [];
+      const watcher = new SecretsWatcher(path, {
+        inForce,
+        onChange: (changed) => changes.push(changed),
+        onError: (error) => errors.push(error),
+      });
+      return { watcher, changes, errors };
+    };
+
+    it('sees a rename over the path', () => {
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545"}');
+      const { watcher, changes } = watcherOn({ PROVIDERS_URLS: 'http://one.example.com:8545' });
+
+      render('{"PROVIDERS_URLS":"http://two.example.com:8545"}', 2);
+
+      expect(watcher.checkOnce()).toBe(true);
+      expect(changes).toEqual([['PROVIDERS_URLS']]);
+    });
+
+    it('does not call an unchanged file a rotation', () => {
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545"}');
+      const { watcher, changes, errors } = watcherOn({ PROVIDERS_URLS: 'http://one.example.com:8545' });
+
+      expect(watcher.checkOnce()).toBe(false);
+
+      // The agent re-renders on a schedule; an identical render moves the mtime and nothing else.
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545"}', 2);
+      expect(watcher.checkOnce()).toBe(false);
+      expect(changes).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('reports a key that disappeared', () => {
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545","CL_API_URLS":"http://cl.example.com"}');
+      const { watcher, changes } = watcherOn({
+        PROVIDERS_URLS: 'http://one.example.com:8545',
+        CL_API_URLS: 'http://cl.example.com',
+      });
+
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545"}', 2);
+
+      expect(watcher.checkOnce()).toBe(true);
+      expect(changes).toEqual([['CL_API_URLS']]);
+    });
+
+    it.each([
+      ['unparseable', 'export PROVIDERS_URLS="http://two.example.com:8545"'],
+      ['empty', ''],
+      ['parsing to nothing', '{}'],
+    ])('keeps the previous values when the render is %s, and reports it once', (_name, contents) => {
+      render('{"PROVIDERS_URLS":"http://one.example.com:8545"}');
+      const { watcher, changes, errors } = watcherOn({ PROVIDERS_URLS: 'http://one.example.com:8545' });
+
+      render(contents, 2);
+
+      expect(watcher.checkOnce()).toBe(false);
+      expect(changes).toEqual([]);
+      expect(errors).toHaveLength(1);
+
+      // The mtime is remembered even for a render that cannot be used, so a broken template is one
+      // log line rather than one per poll for as long as it is broken.
+      expect(watcher.checkOnce()).toBe(false);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('is quiet while there is no file at all', () => {
+      const { watcher, changes, errors } = watcherOn({});
+
+      expect(watcher.checkOnce()).toBe(false);
+      expect(changes).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+  });
+});

--- a/src/common/secrets/secrets.ts
+++ b/src/common/secrets/secrets.ts
@@ -1,33 +1,11 @@
-/**
- * Credentials that arrive as a file, and how a change to one is noticed.
- *
- * Execution and consensus endpoints carry provider credentials. Where they are delivered as a
- * file, a rotation reaches the container without anything restarting the process — and a process
- * cannot be handed new environment variables from outside, so a rotation nobody applies looks
- * exactly like a healthy deployment until the provider revokes the key.
- *
- * The writer replaces the file by renaming a temporary file over the path. That is atomic, so a
- * reader never sees half a file, but it also means a new inode each time — which is why the path
- * is polled with stat() rather than watched. A watcher bound to the file goes silent after the
- * first rotation.
- *
- * No file means the values come from the environment, which is how the non-Kubernetes deployment
- * runs. The variable names and the semantics are a sibling service's, so one description covers
- * both and neither drifts.
- */
+// Credentials delivered as a JSON file. The path is polled, never watched: the writer renames a
+// temp file over it, so the inode changes on every rotation.
 import { readFileSync, statSync } from 'fs';
 
-/** Where the delivering agent is configured to render, and how often the path is checked. */
 export const DEFAULT_SECRETS_FILE_PATH = '/vault/secrets/config';
 export const DEFAULT_SECRETS_POLL_INTERVAL_IN_SECONDS = 10;
 
-/**
- * The file's values, or an empty object when there is no file.
- *
- * Absent is not an error — it is the environment-only deployment. Present but unparseable throws,
- * and every caller here reports it and then carries on with the environment: refusing to start
- * would turn a bad render of one key into an outage of the whole service.
- */
+/** The file's values, or an empty object when there is no file. Throws on an unusable one. */
 export function readSecretsFile(path: string): Record<string, string> {
   if (!path) return {};
 
@@ -52,15 +30,13 @@ export function readSecretsFile(path: string): Record<string, string> {
 
   const values: Record<string, string> = {};
   for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
-    // A key rendered as null is a template that resolved to nothing. Dropped rather than kept as
-    // the string "null", which would reach a URL parser as a hostname.
+    // Dropped rather than kept as the string "null", which a URL parser would take as a hostname.
     if (value === null || value === undefined) continue;
     values[key] = String(value);
   }
   return values;
 }
 
-/** The path's mtime in milliseconds, or null when there is nothing at the path. */
 export function secretsFileMtimeMs(path: string): number | null {
   try {
     return statSync(path).mtimeMs;
@@ -69,13 +45,7 @@ export function secretsFileMtimeMs(path: string): number | null {
   }
 }
 
-/**
- * Makes the file the source of truth for everything read through the environment.
- *
- * One place rather than a lookup at every call site: the values a rotation can change are the
- * ones the environment already carries, and two sources consulted in different orders by
- * different readers is how a service ends up half-rotated. Returns what it applied.
- */
+/** Applies the file over process.env, so every existing reader sees it. Returns what it applied. */
 export function loadSecretsIntoEnv(path: string): Record<string, string> {
   const values = readSecretsFile(path);
   for (const [key, value] of Object.entries(values)) {
@@ -84,7 +54,6 @@ export function loadSecretsIntoEnv(path: string): Record<string, string> {
   return values;
 }
 
-/** Keys whose value differs between two renders, including ones the newer render dropped. */
 export function changedSecretKeys(before: Record<string, string>, after: Record<string, string>): string[] {
   const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
   return [...keys].filter((key) => before[key] !== after[key]).sort();
@@ -92,31 +61,25 @@ export function changedSecretKeys(before: Record<string, string>, after: Record<
 
 export interface SecretsWatcherOptions {
   intervalInSeconds?: number;
-  /** What the process is running on, so a re-render of unchanged values is not a rotation. */
   inForce?: Record<string, string>;
   onChange: (changed: string[], values: Record<string, string>) => void;
   onError: (error: Error) => void;
 }
 
-/** Polls the path and reports a render that actually changed a value. */
 export class SecretsWatcher {
   private mtime: number | null;
   private inForce: Record<string, string>;
   private timer: NodeJS.Timeout | undefined;
 
   constructor(private readonly path: string, private readonly options: SecretsWatcherOptions) {
-    // Starting from the current mtime, so the first poll does not re-report what the process was
-    // configured with.
     this.mtime = secretsFileMtimeMs(path);
     this.inForce = { ...(options.inForce ?? {}) };
   }
 
-  /** True when a changed render was seen. Separate from the loop so the behaviour is testable. */
   public checkOnce(): boolean {
     const mtime = secretsFileMtimeMs(this.path);
     if (mtime === null || mtime === this.mtime) return false;
-    // Remembered before the contents are judged, so an unusable render is reported once rather
-    // than at every poll for as long as it sits there.
+    // Remembered before the contents are judged, so an unusable render is reported once.
     this.mtime = mtime;
 
     let values: Record<string, string>;
@@ -135,7 +98,7 @@ export class SecretsWatcher {
     }
 
     const changed = changedSecretKeys(this.inForce, values);
-    // The agent re-renders on a schedule; only a render that moved a value is a rotation.
+    // The writer re-renders on a schedule; only a changed value is a rotation.
     if (changed.length === 0) return false;
 
     this.inForce = values;
@@ -147,7 +110,6 @@ export class SecretsWatcher {
     if (this.timer) return;
     const seconds = this.options.intervalInSeconds ?? DEFAULT_SECRETS_POLL_INTERVAL_IN_SECONDS;
     this.timer = setInterval(() => this.checkOnce(), seconds * 1000);
-    // The poll must never be the reason the process is still alive while it is shutting down.
     this.timer.unref();
   }
 

--- a/src/common/secrets/secrets.ts
+++ b/src/common/secrets/secrets.ts
@@ -1,0 +1,158 @@
+/**
+ * Credentials that arrive as a file, and how a change to one is noticed.
+ *
+ * Execution and consensus endpoints carry provider credentials. Where they are delivered as a
+ * file, a rotation reaches the container without anything restarting the process — and a process
+ * cannot be handed new environment variables from outside, so a rotation nobody applies looks
+ * exactly like a healthy deployment until the provider revokes the key.
+ *
+ * The writer replaces the file by renaming a temporary file over the path. That is atomic, so a
+ * reader never sees half a file, but it also means a new inode each time — which is why the path
+ * is polled with stat() rather than watched. A watcher bound to the file goes silent after the
+ * first rotation.
+ *
+ * No file means the values come from the environment, which is how the non-Kubernetes deployment
+ * runs. The variable names and the semantics are a sibling service's, so one description covers
+ * both and neither drifts.
+ */
+import { readFileSync, statSync } from 'fs';
+
+/** Where the delivering agent is configured to render, and how often the path is checked. */
+export const DEFAULT_SECRETS_FILE_PATH = '/vault/secrets/config';
+export const DEFAULT_SECRETS_POLL_INTERVAL_IN_SECONDS = 10;
+
+/**
+ * The file's values, or an empty object when there is no file.
+ *
+ * Absent is not an error — it is the environment-only deployment. Present but unparseable throws,
+ * and every caller here reports it and then carries on with the environment: refusing to start
+ * would turn a bad render of one key into an outage of the whole service.
+ */
+export function readSecretsFile(path: string): Record<string, string> {
+  if (!path) return {};
+
+  let blob: string;
+  try {
+    blob = readFileSync(path, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw new Error(`Can not read secrets file ${path}: ${(error as Error).message}`);
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(blob);
+  } catch (error) {
+    throw new Error(`Can not parse secrets file ${path}: ${(error as Error).message}`);
+  }
+
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`Secrets file ${path} is not a JSON object`);
+  }
+
+  const values: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    // A key rendered as null is a template that resolved to nothing. Dropped rather than kept as
+    // the string "null", which would reach a URL parser as a hostname.
+    if (value === null || value === undefined) continue;
+    values[key] = String(value);
+  }
+  return values;
+}
+
+/** The path's mtime in milliseconds, or null when there is nothing at the path. */
+export function secretsFileMtimeMs(path: string): number | null {
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Makes the file the source of truth for everything read through the environment.
+ *
+ * One place rather than a lookup at every call site: the values a rotation can change are the
+ * ones the environment already carries, and two sources consulted in different orders by
+ * different readers is how a service ends up half-rotated. Returns what it applied.
+ */
+export function loadSecretsIntoEnv(path: string): Record<string, string> {
+  const values = readSecretsFile(path);
+  for (const [key, value] of Object.entries(values)) {
+    process.env[key] = value;
+  }
+  return values;
+}
+
+/** Keys whose value differs between two renders, including ones the newer render dropped. */
+export function changedSecretKeys(before: Record<string, string>, after: Record<string, string>): string[] {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  return [...keys].filter((key) => before[key] !== after[key]).sort();
+}
+
+export interface SecretsWatcherOptions {
+  intervalInSeconds?: number;
+  /** What the process is running on, so a re-render of unchanged values is not a rotation. */
+  inForce?: Record<string, string>;
+  onChange: (changed: string[], values: Record<string, string>) => void;
+  onError: (error: Error) => void;
+}
+
+/** Polls the path and reports a render that actually changed a value. */
+export class SecretsWatcher {
+  private mtime: number | null;
+  private inForce: Record<string, string>;
+  private timer: NodeJS.Timeout | undefined;
+
+  constructor(private readonly path: string, private readonly options: SecretsWatcherOptions) {
+    // Starting from the current mtime, so the first poll does not re-report what the process was
+    // configured with.
+    this.mtime = secretsFileMtimeMs(path);
+    this.inForce = { ...(options.inForce ?? {}) };
+  }
+
+  /** True when a changed render was seen. Separate from the loop so the behaviour is testable. */
+  public checkOnce(): boolean {
+    const mtime = secretsFileMtimeMs(this.path);
+    if (mtime === null || mtime === this.mtime) return false;
+    // Remembered before the contents are judged, so an unusable render is reported once rather
+    // than at every poll for as long as it sits there.
+    this.mtime = mtime;
+
+    let values: Record<string, string>;
+    try {
+      values = readSecretsFile(this.path);
+    } catch (error) {
+      this.options.onError(error as Error);
+      return false;
+    }
+
+    if (Object.keys(values).length === 0) {
+      this.options.onError(
+        new Error(`Secrets file ${this.path} changed but has no usable values, keeping the previous ones`),
+      );
+      return false;
+    }
+
+    const changed = changedSecretKeys(this.inForce, values);
+    // The agent re-renders on a schedule; only a render that moved a value is a rotation.
+    if (changed.length === 0) return false;
+
+    this.inForce = values;
+    this.options.onChange(changed, values);
+    return true;
+  }
+
+  public start(): void {
+    if (this.timer) return;
+    const seconds = this.options.intervalInSeconds ?? DEFAULT_SECRETS_POLL_INTERVAL_IN_SECONDS;
+    this.timer = setInterval(() => this.checkOnce(), seconds * 1000);
+    // The poll must never be the reason the process is still alive while it is shutting down.
+    this.timer.unref();
+  }
+
+  public stop(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+}

--- a/src/http/common/cache/cache-headers.interceptor.spec.ts
+++ b/src/http/common/cache/cache-headers.interceptor.spec.ts
@@ -1,0 +1,69 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { CacheHeadersInterceptor, NO_STORE_CACHE_CONTROL, PUBLIC_GET_CACHE_CONTROL } from './cache-headers.interceptor';
+
+describe('CacheHeadersInterceptor', () => {
+  const makeResponse = () => {
+    const headers: Record<string, string> = {};
+    return {
+      headers,
+      sent: false,
+      header(name: string, value: string) {
+        headers[name] = value;
+      },
+    };
+  };
+
+  const makeContext = (method: string, response: ReturnType<typeof makeResponse>): ExecutionContext =>
+    ({
+      getType: () => 'http',
+      getHandler: () => ({}),
+      getClass: () => ({}),
+      switchToHttp: () => ({
+        getRequest: () => ({ method }),
+        getResponse: () => response,
+      }),
+    } as unknown as ExecutionContext);
+
+  const makeInterceptor = (skip: boolean) => {
+    const reflector = { getAllAndOverride: jest.fn().mockReturnValue(skip) } as unknown as Reflector;
+    return new CacheHeadersInterceptor(reflector);
+  };
+
+  const next = (result = 'payload'): CallHandler => ({ handle: () => of(result) });
+
+  it('sets the public header on a successful GET', async () => {
+    const response = makeResponse();
+    await lastValueFrom(makeInterceptor(false).intercept(makeContext('GET', response), next()));
+    expect(response.headers['Cache-Control']).toBe(PUBLIC_GET_CACHE_CONTROL);
+  });
+
+  it('sets no-store on routes marked with SkipCache', async () => {
+    const response = makeResponse();
+    await lastValueFrom(makeInterceptor(true).intercept(makeContext('GET', response), next()));
+    expect(response.headers['Cache-Control']).toBe(NO_STORE_CACHE_CONTROL);
+  });
+
+  it('sets no header when the handler errors', async () => {
+    const response = makeResponse();
+    const failing: CallHandler = { handle: () => throwError(() => new Error('boom')) };
+    await expect(
+      lastValueFrom(makeInterceptor(false).intercept(makeContext('GET', response), failing)),
+    ).rejects.toThrow('boom');
+    expect(response.headers['Cache-Control']).toBeUndefined();
+  });
+
+  it('sets no header on non-GET requests', async () => {
+    const response = makeResponse();
+    await lastValueFrom(makeInterceptor(false).intercept(makeContext('POST', response), next()));
+    expect(response.headers['Cache-Control']).toBeUndefined();
+  });
+
+  it('does not touch a response that is already sent', async () => {
+    const response = makeResponse();
+    response.sent = true;
+    await lastValueFrom(makeInterceptor(false).intercept(makeContext('GET', response), next()));
+    expect(response.headers['Cache-Control']).toBeUndefined();
+  });
+});

--- a/src/http/common/cache/cache-headers.interceptor.ts
+++ b/src/http/common/cache/cache-headers.interceptor.ts
@@ -1,0 +1,46 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { SKIP_CACHE_KEY } from 'common/decorators/skipCache';
+
+// Lido default for rarely changing public GETs, so the CDN can absorb load on the heavy
+// endpoints instead of passing every request to origin.
+export const PUBLIC_GET_CACHE_CONTROL = 'public, max-age=30, stale-if-error=1200, stale-while-revalidate=30';
+
+// Probe and metrics answers must never be reused by any cache: a stored 200 keeps answering
+// through an outage.
+export const NO_STORE_CACHE_CONTROL = 'no-store';
+
+@Injectable()
+export class CacheHeadersInterceptor implements NestInterceptor {
+  constructor(protected readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    if (context.getType() !== 'http') return next.handle();
+
+    const request = context.switchToHttp().getRequest();
+    if (request.method !== 'GET') return next.handle();
+
+    const response = context.switchToHttp().getResponse();
+
+    // The routes that skip the in-process response cache are exactly the ones no shared cache
+    // may store either: probes and metrics.
+    const skip = this.reflector.getAllAndOverride<boolean>(SKIP_CACHE_KEY, [context.getHandler(), context.getClass()]);
+    if (skip) {
+      response.header('Cache-Control', NO_STORE_CACHE_CONTROL);
+      return next.handle();
+    }
+
+    // On success only: an error response carrying `public` could be stored by a shared cache,
+    // pinning a 4xx/5xx for max-age. tap fires before the body is written, so streamed
+    // responses get the header too.
+    return next.handle().pipe(
+      tap(() => {
+        if (!response.sent) {
+          response.header('Cache-Control', PUBLIC_GET_CACHE_CONTROL);
+        }
+      }),
+    );
+  }
+}

--- a/src/http/http.module.ts
+++ b/src/http/http.module.ts
@@ -16,6 +16,7 @@ import { SRModulesOperatorsModule } from './sr-modules-operators';
 import { SRModulesOperatorsKeysModule } from './sr-modules-operators-keys';
 import { StatusModule } from './status';
 import { CustomCacheInterceptor } from './common/cache/cache.service';
+import { CacheHeadersInterceptor } from './common/cache/cache-headers.interceptor';
 
 @Module({
   imports: [
@@ -31,6 +32,9 @@ import { CustomCacheInterceptor } from './common/cache/cache.service';
   ],
   providers: [
     { provide: APP_GUARD, useClass: ThrottlerBehindProxyGuard },
+    // Before the response cache: a cache hit short-circuits the chain, and interceptors
+    // registered after it would never stamp the Cache-Control header on hits.
+    { provide: APP_INTERCEPTOR, useClass: CacheHeadersInterceptor },
     { provide: APP_INTERCEPTOR, useClass: CustomCacheInterceptor },
   ],
 })

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -30,6 +30,9 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       );
       clearInterval(intervalUpdateValidators);
     } catch {}
+    // The keys-update deadline is a plain setTimeout, so the scheduler registry above does not
+    // know about it. Left running it keeps the event loop alive for its full hour.
+    this.keysUpdateService.clearUpdateDeadline();
   }
 
   /**

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -30,8 +30,8 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
       );
       clearInterval(intervalUpdateValidators);
     } catch {}
-    // The keys-update deadline is a plain setTimeout, so the scheduler registry above does not
-    // know about it. Left running it keeps the event loop alive for its full hour.
+    // A plain setTimeout, so the registry above does not know about it and it holds the event
+    // loop open for its full hour.
     this.keysUpdateService.clearUpdateDeadline();
   }
 

--- a/src/jobs/keys-update/keys-update.service.ts
+++ b/src/jobs/keys-update/keys-update.service.ts
@@ -71,6 +71,11 @@ export class KeysUpdateService {
     this.logger.log('Finished KeysUpdateService initialization');
   }
 
+  public clearUpdateDeadline(): void {
+    if (this.updateDeadlineTimer) clearTimeout(this.updateDeadlineTimer);
+    this.updateDeadlineTimer = undefined;
+  }
+
   private checkKeysUpdateTimeout() {
     const currTimestampSec = new Date().getTime() / 1000;
     // currTimestampSec - this.lastTimestampSec - Time since last update in seconds

--- a/src/jobs/keys-update/keys-update.service.ts
+++ b/src/jobs/keys-update/keys-update.service.ts
@@ -159,16 +159,39 @@ export class KeysUpdateService {
       process.exit(1);
     }
 
-    await this.entityManager.transactional(
-      async () => {
+    // READ_COMMITTED alone allows a lost update — a writer holding an older block overwrites a newer one — so the
+    // meta is re-read under the lock and the cycle is skipped when it has already moved on.
+    const updated = await this.entityManager.transactional(
+      async (em) => {
+        const [{ locked }] = await em.execute<{ locked: boolean }[]>(
+          "select pg_try_advisory_xact_lock(hashtext('lido-keys-api:keys-update')) as locked",
+        );
+        if (!locked) {
+          this.logger.warn('Another instance is writing the keys update, skipping this cycle');
+          return false;
+        }
+
+        const metaNow = await this.elMetaStorage.get();
+        if (metaNow && metaNow.blockNumber > currElMeta.number) {
+          this.logger.warn('Another instance stored a newer block, skipping this cycle', { metaNow, currElMeta });
+          return false;
+        }
+        if (metaNow && metaNow.blockHash === currElMeta.hash) {
+          this.logger.log('Another instance stored the same block, updating is not required', { currElMeta });
+          return false;
+        }
+
         await this.stakingModuleUpdaterService.updateStakingModules({
           currElMeta,
-          prevElMeta,
+          prevElMeta: metaNow,
           contractModules,
         });
+        return true;
       },
       { isolationLevel: IsolationLevel.READ_COMMITTED },
     );
+
+    if (!updated) return;
 
     return currElMeta;
   }

--- a/src/jobs/keys-update/test/update-lock.spec.ts
+++ b/src/jobs/keys-update/test/update-lock.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConfigService } from 'common/config';
+import { JobService } from 'common/job';
+import { PrometheusService } from 'common/prometheus';
+import { ExecutionProviderService } from 'common/execution-provider';
+import { StakingRouterService } from 'staking-router-modules/staking-router.service';
+import { StakingRouterFetchService } from 'staking-router-modules/contracts';
+import { ElMetaStorageService } from 'storage/el-meta.storage';
+import { SRModuleStorageService } from 'storage/sr-module.storage';
+import { EntityManager } from '@mikro-orm/knex';
+import { KeysUpdateService } from '../keys-update.service';
+import { StakingModuleUpdaterService } from '../staking-module-updater.service';
+
+describe('KeysUpdateService update: advisory lock and re-read under it', () => {
+  const currElMeta = { number: 200, hash: '0xcurr', timestamp: 2000 };
+  const prevElMeta = { blockNumber: 100, blockHash: '0xprev', timestamp: 1000 };
+
+  let keysUpdateService: KeysUpdateService;
+  let updateStakingModules: jest.Mock;
+  let elMetaGet: jest.Mock;
+  let execute: jest.Mock;
+
+  const build = async () => {
+    updateStakingModules = jest.fn();
+    execute = jest.fn().mockResolvedValue([{ locked: true }]);
+    elMetaGet = jest.fn().mockResolvedValue(prevElMeta);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: JobService, useValue: {} },
+        { provide: SchedulerRegistry, useValue: {} },
+        { provide: StakingRouterService, useValue: {} },
+        { provide: StakingRouterFetchService, useValue: { getStakingModules: jest.fn().mockResolvedValue([]) } },
+        { provide: ElMetaStorageService, useValue: { get: (...args) => elMetaGet(...args) } },
+        {
+          provide: EntityManager,
+          useValue: { transactional: (cb: (em: unknown) => Promise<unknown>) => cb({ execute }) },
+        },
+        { provide: ExecutionProviderService, useValue: { getBlock: jest.fn().mockResolvedValue(currElMeta) } },
+        { provide: SRModuleStorageService, useValue: { findAll: jest.fn().mockResolvedValue([]) } },
+        { provide: PrometheusService, useValue: {} },
+        { provide: StakingModuleUpdaterService, useValue: { updateStakingModules } },
+        KeysUpdateService,
+      ],
+    }).compile();
+
+    keysUpdateService = module.get(KeysUpdateService);
+  };
+
+  it('skips the cycle without writing when another instance holds the lock', async () => {
+    await build();
+    execute.mockResolvedValue([{ locked: false }]);
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('skips when the re-read under the lock sees a newer block', async () => {
+    await build();
+    elMetaGet
+      .mockResolvedValueOnce(prevElMeta)
+      .mockResolvedValueOnce({ blockNumber: 300, blockHash: '0xnewer', timestamp: 3000 });
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('skips when the re-read under the lock sees the same block already stored', async () => {
+    await build();
+    elMetaGet
+      .mockResolvedValueOnce(prevElMeta)
+      .mockResolvedValueOnce({ blockNumber: 200, blockHash: '0xcurr', timestamp: 2000 });
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('writes against the meta read under the lock, not the one read before it', async () => {
+    await build();
+    const metaUnderLock = { blockNumber: 150, blockHash: '0xmid', timestamp: 1500 };
+    elMetaGet.mockResolvedValueOnce(prevElMeta).mockResolvedValueOnce(metaUnderLock);
+
+    expect(await keysUpdateService.update()).toEqual(currElMeta);
+    expect(updateStakingModules).toHaveBeenCalledWith(
+      expect.objectContaining({ currElMeta, prevElMeta: metaUnderLock }),
+    );
+  });
+});

--- a/src/jobs/validators-update/test/update-lock.spec.ts
+++ b/src/jobs/validators-update/test/update-lock.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConfigService } from 'common/config';
+import { JobService } from 'common/job';
+import { PrometheusService } from 'common/prometheus';
+import { ValidatorsService } from 'validators';
+import { EntityManager } from '@mikro-orm/knex';
+import { ValidatorsUpdateService } from '../validators-update.service';
+
+describe('ValidatorsUpdateService update: advisory lock around the registry write', () => {
+  const meta = {
+    epoch: 10,
+    slot: 320,
+    slotStateRoot: '0xstate',
+    blockNumber: 200,
+    blockHash: '0xcurr',
+    timestamp: 2000,
+  };
+
+  let validatorsUpdateService: ValidatorsUpdateService;
+  let updateValidators: jest.Mock;
+  let execute: jest.Mock;
+
+  const build = async () => {
+    updateValidators = jest.fn().mockResolvedValue(meta);
+    execute = jest.fn().mockResolvedValue([{ locked: true }]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: JobService, useValue: {} },
+        { provide: SchedulerRegistry, useValue: {} },
+        { provide: PrometheusService, useValue: {} },
+        { provide: ValidatorsService, useValue: { updateValidators: (...args) => updateValidators(...args) } },
+        {
+          provide: EntityManager,
+          useValue: { transactional: (cb: (em: unknown) => Promise<unknown>) => cb({ execute }) },
+        },
+        ValidatorsUpdateService,
+      ],
+    }).compile();
+
+    validatorsUpdateService = module.get(ValidatorsUpdateService);
+  };
+
+  it('skips the cycle without writing when another instance holds the lock', async () => {
+    await build();
+    execute.mockResolvedValue([{ locked: false }]);
+
+    expect(await validatorsUpdateService['updateValidatorsUnderLock']()).toBeNull();
+    expect(updateValidators).not.toHaveBeenCalled();
+  });
+
+  it('writes the finalized state when it takes the lock', async () => {
+    await build();
+
+    expect(await validatorsUpdateService['updateValidatorsUnderLock']()).toEqual(meta);
+    expect(updateValidators).toHaveBeenCalledWith('finalized');
+  });
+
+  it('takes a lock of its own, not the one the keys update takes', async () => {
+    await build();
+
+    await validatorsUpdateService['updateValidatorsUnderLock']();
+    expect(execute).toHaveBeenCalledWith(expect.stringContaining('lido-keys-api:validators-update'));
+  });
+});

--- a/src/jobs/validators-update/validators-update.service.ts
+++ b/src/jobs/validators-update/validators-update.service.ts
@@ -6,6 +6,9 @@ import { JobService } from 'common/job';
 import { ValidatorsService } from 'validators';
 import { OneAtTime } from 'common/decorators/oneAtTime';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/knex';
+import { IsolationLevel } from '@mikro-orm/core';
+import { ConsensusMeta } from '@lido-nestjs/validators-registry';
 
 export interface ValidatorsFilter {
   pubkeys: string[];
@@ -32,6 +35,7 @@ export class ValidatorsUpdateService {
     protected readonly jobService: JobService,
     protected readonly validatorsService: ValidatorsService,
     protected readonly schedulerRegistry: SchedulerRegistry,
+    protected readonly entityManager: EntityManager,
   ) {}
 
   // prometheus metrics
@@ -87,10 +91,29 @@ export class ValidatorsUpdateService {
     }, this.UPDATE_VALIDATORS_TIMEOUT_MS);
   }
 
+  // `updateStream` reads the stored meta outside its own write transaction, so an older-slot writer drops a newer set
+  // unless the lock covers that read: MikroORM carries this transaction into the registry's own entity manager.
+  private async updateValidatorsUnderLock(): Promise<ConsensusMeta | null> {
+    return this.entityManager.transactional(
+      async (em) => {
+        const [{ locked }] = await em.execute<{ locked: boolean }[]>(
+          "select pg_try_advisory_xact_lock(hashtext('lido-keys-api:validators-update')) as locked",
+        );
+        if (!locked) {
+          this.logger.warn('Another instance is writing the validators update, skipping this cycle');
+          return null;
+        }
+
+        return this.validatorsService.updateValidators('finalized');
+      },
+      { isolationLevel: IsolationLevel.READ_COMMITTED },
+    );
+  }
+
   @OneAtTime()
   private async updateValidators() {
     await this.jobService.wrapJob({ name: 'Update validators from ValidatorsRegistry' }, async () => {
-      const meta = await this.validatorsService.updateValidators('finalized');
+      const meta = await this.updateValidatorsUnderLock();
       // meta shouldn't be null
       // if update didnt happen, meta will be fetched from db
       this.lastBlockTimestampSec = meta?.timestamp ?? this.lastBlockTimestampSec;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,6 @@
+// First, and deliberately: it puts the secrets file into the environment, and the imports below
+// read the environment while they are being loaded. See common/secrets/bootstrap-env.
+import { SECRETS_FILE_PATH, SECRETS_IN_FORCE, SECRETS_POLL_INTERVAL_IN_SECONDS } from './common/secrets/bootstrap-env';
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
@@ -8,8 +11,14 @@ import { SWAGGER_URL } from './http/common/swagger';
 import { ConfigService } from './common/config';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from './app';
 import { MikroORM } from '@mikro-orm/core';
+import { PrometheusService } from './common/prometheus';
+import { SecretsWatcher, secretsFileMtimeMs } from './common/secrets';
 
 export const validationOpt = { transform: true };
+
+// How long a shutdown may take before this process stops waiting for itself. Well under any
+// termination grace period an orchestrator gives it, so the exit is always ours.
+const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
@@ -17,6 +26,9 @@ async function bootstrap() {
     new FastifyAdapter({
       trustProxy: true,
       ignoreTrailingSlash: true,
+      // Idle keep-alive connections are dropped instead of being waited out. Not the whole of the
+      // shutdown story — see the handler below — but it is what makes close() itself prompt.
+      forceCloseConnections: true,
     }),
     {
       bufferLogs: true,
@@ -40,9 +52,63 @@ async function bootstrap() {
   const logger: Logger = app.get(LOGGER_PROVIDER);
   app.useLogger(logger);
 
-  // enable onShutdownHooks for MikroORM to close DB connection
-  // when application exits normally
-  app.enableShutdownHooks();
+  // Which of the two sources the process is running on. Nothing else in the logs says it, and
+  // "why is it still using the old endpoint" cannot be answered without it.
+  const fromFile = Object.keys(SECRETS_IN_FORCE).length > 0;
+  logger.log(
+    fromFile
+      ? `Configuration: ${SECRETS_FILE_PATH} over the environment`
+      : `Configuration: the environment (no secrets file at ${SECRETS_FILE_PATH})`,
+  );
+
+  const prometheusService = app.get(PrometheusService);
+  prometheusService.secretsFileMtime.set(fromFile ? (secretsFileMtimeMs(SECRETS_FILE_PATH) ?? 0) / 1000 : 0);
+
+  // Nest's own signal handling is not used. It closes the application and leaves the process to
+  // exit on its own, which it never does: dependencies hold timers that outlive the application,
+  // and the orchestrator ends up killing the container at the end of the grace period instead.
+  // app.close() still runs the destroy and shutdown hooks, so the ORM closes its connection here
+  // exactly as it did under enableShutdownHooks().
+  let shuttingDown = false;
+  const shutdown = async (reason: string, code: number) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logger.log(`Shutting down: ${reason}`);
+
+    // A shutdown this process asks for is bounded by nothing, so it is bounded here.
+    const deadline = setTimeout(() => {
+      logger.error(`Shutdown did not finish within ${SHUTDOWN_TIMEOUT_MS} ms, exiting anyway`);
+      process.exit(code);
+    }, SHUTDOWN_TIMEOUT_MS);
+
+    try {
+      await app.close();
+    } catch (error) {
+      logger.error(error);
+    }
+    clearTimeout(deadline);
+    process.exit(code);
+  };
+
+  for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+    process.on(signal, () => void shutdown(signal, 0));
+  }
+
+  // A rotated credential has to reach the process, and on staging and production nothing outside
+  // it can restart it. So it notices and exits, and the orchestrator starts it again with the new
+  // values read the ordinary way — far less code, and far fewer failure modes, than swapping
+  // clients inside a running process.
+  if (fromFile) {
+    new SecretsWatcher(SECRETS_FILE_PATH, {
+      intervalInSeconds: SECRETS_POLL_INTERVAL_IN_SECONDS,
+      inForce: SECRETS_IN_FORCE,
+      onChange: (changed) => {
+        logger.log(`Secrets file changed (${changed.join(', ')}), exiting so the new values are read at start`);
+        void shutdown('rotated secrets', 0);
+      },
+      onError: (error) => logger.error(error),
+    }).start();
+  }
 
   // handling uncaught exceptions when application exits abnormally
   process.on('uncaughtException', async (error) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
 import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
 import { SWAGGER_URL } from './http/common/swagger';
-import { ConfigService } from './common/config';
+import { ConfigService, VALIDATED_ENV } from './common/config';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from './app';
 import { MikroORM } from '@mikro-orm/core';
 import { PrometheusService } from './common/prometheus';
@@ -53,12 +53,15 @@ async function bootstrap() {
       ? `Configuration: ${SECRETS_FILE_PATH} over the environment`
       : `Configuration: the environment (no secrets file at ${SECRETS_FILE_PATH})`,
   );
+  // Defaults included, unlike a dump of process.env. The logger's secrets format masks
+  // every value from configService.secrets in this line.
+  logger.log(`Effective configuration: ${JSON.stringify(VALIDATED_ENV)}`);
 
   const prometheusService = app.get(PrometheusService);
   prometheusService.secretsFileMtime.set(fromFile ? (secretsFileMtimeMs(SECRETS_FILE_PATH) ?? 0) / 1000 : 0);
 
-    // Not enableShutdownHooks: it leaves the process to exit on its own, and dependencies hold
-    // timers that outlive the application. close() still runs the destroy hooks.
+  // Not enableShutdownHooks: it leaves the process to exit on its own, and dependencies hold
+  // timers that outlive the application. close() still runs the destroy hooks.
   let shuttingDown = false;
   const shutdown = async (reason: string, code: number) => {
     if (shuttingDown) return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
-// First, and deliberately: it puts the secrets file into the environment, and the imports below
-// read the environment while they are being loaded. See common/secrets/bootstrap-env.
+// First: the imports below read process.env while they load.
 import { SECRETS_FILE_PATH, SECRETS_IN_FORCE, SECRETS_POLL_INTERVAL_IN_SECONDS } from './common/secrets/bootstrap-env';
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe, VersioningType } from '@nestjs/common';
@@ -16,8 +15,6 @@ import { SecretsWatcher, secretsFileMtimeMs } from './common/secrets';
 
 export const validationOpt = { transform: true };
 
-// How long a shutdown may take before this process stops waiting for itself. Well under any
-// termination grace period an orchestrator gives it, so the exit is always ours.
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
 async function bootstrap() {
@@ -26,8 +23,6 @@ async function bootstrap() {
     new FastifyAdapter({
       trustProxy: true,
       ignoreTrailingSlash: true,
-      // Idle keep-alive connections are dropped instead of being waited out. Not the whole of the
-      // shutdown story — see the handler below — but it is what makes close() itself prompt.
       forceCloseConnections: true,
     }),
     {
@@ -52,8 +47,6 @@ async function bootstrap() {
   const logger: Logger = app.get(LOGGER_PROVIDER);
   app.useLogger(logger);
 
-  // Which of the two sources the process is running on. Nothing else in the logs says it, and
-  // "why is it still using the old endpoint" cannot be answered without it.
   const fromFile = Object.keys(SECRETS_IN_FORCE).length > 0;
   logger.log(
     fromFile
@@ -64,18 +57,14 @@ async function bootstrap() {
   const prometheusService = app.get(PrometheusService);
   prometheusService.secretsFileMtime.set(fromFile ? (secretsFileMtimeMs(SECRETS_FILE_PATH) ?? 0) / 1000 : 0);
 
-  // Nest's own signal handling is not used. It closes the application and leaves the process to
-  // exit on its own, which it never does: dependencies hold timers that outlive the application,
-  // and the orchestrator ends up killing the container at the end of the grace period instead.
-  // app.close() still runs the destroy and shutdown hooks, so the ORM closes its connection here
-  // exactly as it did under enableShutdownHooks().
+    // Not enableShutdownHooks: it leaves the process to exit on its own, and dependencies hold
+    // timers that outlive the application. close() still runs the destroy hooks.
   let shuttingDown = false;
   const shutdown = async (reason: string, code: number) => {
     if (shuttingDown) return;
     shuttingDown = true;
     logger.log(`Shutting down: ${reason}`);
 
-    // A shutdown this process asks for is bounded by nothing, so it is bounded here.
     const deadline = setTimeout(() => {
       logger.error(`Shutdown did not finish within ${SHUTDOWN_TIMEOUT_MS} ms, exiting anyway`);
       process.exit(code);
@@ -94,10 +83,7 @@ async function bootstrap() {
     process.on(signal, () => void shutdown(signal, 0));
   }
 
-  // A rotated credential has to reach the process, and on staging and production nothing outside
-  // it can restart it. So it notices and exits, and the orchestrator starts it again with the new
-  // values read the ordinary way — far less code, and far fewer failure modes, than swapping
-  // clients inside a running process.
+  // Exit rather than swap clients in a live process: the supervisor restarts it with the new values.
   if (fromFile) {
     new SecretsWatcher(SECRETS_FILE_PATH, {
       intervalInSeconds: SECRETS_POLL_INTERVAL_IN_SECONDS,

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { SWAGGER_URL } from './http/common/swagger';
 import { ConfigService } from './common/config';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from './app';
 import { MikroORM } from '@mikro-orm/core';
+import { EntityManager } from '@mikro-orm/knex';
 
 export const validationOpt = { transform: true };
 
@@ -30,8 +31,13 @@ async function bootstrap() {
   const corsWhitelist = configService.get('CORS_WHITELIST_REGEXP');
   const sentryDsn = configService.get('SENTRY_DSN') ?? undefined;
 
-  // migrating when starting application
-  await app.get(MikroORM).getMigrator().up();
+  // Concurrent `migrator.up()` on a fresh database races two `create table` into a pg_type unique violation; the
+  // losers of the lock find the migrations already applied.
+  const orm = app.get(MikroORM);
+  await orm.em.transactional(async (em) => {
+    await (em as EntityManager).execute("select pg_advisory_xact_lock(hashtext('lido-keys-api:migrations'))");
+    await orm.getMigrator().up();
+  });
 
   // versions
   app.enableVersioning({ type: VersioningType.URI });


### PR DESCRIPTION
Prepares lido-keys-api to run under an orchestrator, and closes the k8s-shaped inventory rows of STC-885.

## Orchestrator readiness

- `dev` image build into the team registry, copied from the shared workflow; `ci-dev.yml` keeps running until the cutover.
- Prompt shutdown: was killed at the grace deadline (30 s, exit 137), now exits in ~0.3 s. The cause was not keep-alive connections but two referenced timers surviving `app.close()` — the process now exits explicitly after close, with a deadline in case close itself hangs.
- Credential rotation: secrets can be read from a JSON file (`SECRETS_FILE_PATH`, polled). On a changed value the process logs and exits for the supervisor to restart; an unusable file keeps the previous values and does not restart. One gotcha worth knowing: the path is stat'ed rather than watched, because the writer renames a temp file over it — a watch goes silent after the first rotation.
- `GET /health/ready`: 503 until the DB answers and the first meta row exists; `/health` stays the liveness target.

## Inventory rows (STC-885)

- Cache-Control: successful public GETs get `public, max-age=30, stale-if-error=1200, stale-while-revalidate=30`; probes and `/metrics` get `no-store`; error responses carry nothing, so a shared cache cannot pin a 4xx/5xx. The interceptor sits before the response cache — a cache hit short-circuits anything registered after it.
- Masking: every secrets-file value and `DB_PASSWORD` join the logger's secret list; startup logs a masked effective-config dump; env-validation errors are masked by the same replacement (the logger does not exist yet at that point).
- build-info.json: read at startup, `build_info` gains `commit`/`branch` labels.
- Dockerfile: manifests copied before source so the install layer survives source changes; production-only `node_modules` in the runtime stage.
- User-Agent `lido-keys-api/<version>` on outgoing EL and CL requests.

## Verification

Unit tests per area. Live: k3d against a real testnet endpoint for shutdown, rotation and readiness (rotation timed writer→file and file→ready; unusable files leave the restart count at zero); container smoke for the headers, `build_info` labels and the EL User-Agent.
