### PR TITLE
Multi-instance KAPI: read-only API replicas and a single updater

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -52,6 +52,11 @@ CL_API_URLS=https://quiknode.pro/<token>
 # value below is default
 VALIDATOR_REGISTRY_ENABLE=true
 
+# false turns this instance into a read-only API replica: no background updaters run,
+# HTTP behavior does not change. Run the updaters in a single separate instance instead.
+# value below is default
+UPDATE_JOBS_ENABLE=true
+
 # When streaming lasts more than STREAM_TIMEOUT seconds, the stream will be destroyed
 # This prevents the retrieval of outdated data.
 STREAM_TIMEOUT=60000

--- a/src/common/config/env.validation.spec.ts
+++ b/src/common/config/env.validation.spec.ts
@@ -847,6 +847,16 @@ describe('Environment validation', () => {
     });
   });
 
+  describe('UPDATE_JOBS_ENABLE', () => {
+    it('defaults to true', () => {
+      expect(runValidation(required_configs).UPDATE_JOBS_ENABLE).toBe(true);
+    });
+
+    it('parses false', () => {
+      expect(runValidation({ ...required_configs, UPDATE_JOBS_ENABLE: 'false' }).UPDATE_JOBS_ENABLE).toBe(false);
+    });
+  });
+
   describe('maskSecretsInValidationOutput', () => {
     const config = {
       // nosemgrep: semgrep.detected-generic-secrets -- test-only non-secret value

--- a/src/common/config/env.validation.ts
+++ b/src/common/config/env.validation.ts
@@ -184,6 +184,13 @@ export class EnvironmentVariables {
 
   // Enable endpoints that use CL API for ejector
   @IsOptional()
+  // false turns this instance into a read-only API replica: neither the keys-update nor the
+  // validators-update job starts, HTTP behavior does not change. The updaters then run in a
+  // separate single-replica worker instance with this flag left on.
+  @IsBoolean()
+  @Transform(toBoolean({ defaultValue: true }))
+  UPDATE_JOBS_ENABLE = true;
+
   @IsBoolean()
   @Transform(toBoolean({ defaultValue: true }))
   VALIDATOR_REGISTRY_ENABLE = true;

--- a/src/common/prometheus/prometheus.service.ts
+++ b/src/common/prometheus/prometheus.service.ts
@@ -110,6 +110,12 @@ export class PrometheusService {
     help: 'Validators registry is enabled',
   });
 
+  public updateJobsEnabled = this.getOrCreateMetric('Gauge', {
+    prefix: true,
+    name: 'update_jobs_enabled',
+    help: 'Update jobs run in this instance (0 = read-only API replica)',
+  });
+
   // A gauge, not a counter: the process exits on a change, so a counter would be reset by the
   // restart it records.
   public secretsFileMtime = this.getOrCreateMetric('Gauge', {

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { LOGGER_PROVIDER, LoggerService } from 'common/logger';
+import { ConfigService } from 'common/config';
 import { ValidatorsUpdateService } from './validators-update/validators-update.service';
 import { KeysUpdateService } from './keys-update';
 import { SchedulerRegistry } from '@nestjs/schedule';
@@ -9,6 +10,7 @@ import { PrometheusService } from 'common/prometheus';
 export class JobsService implements OnModuleInit, OnModuleDestroy {
   constructor(
     @Inject(LOGGER_PROVIDER) protected readonly logger: LoggerService,
+    protected readonly configService: ConfigService,
     protected readonly keysUpdateService: KeysUpdateService,
     protected readonly validatorUpdateService: ValidatorsUpdateService,
     protected readonly schedulerRegistry: SchedulerRegistry,
@@ -39,6 +41,15 @@ export class JobsService implements OnModuleInit, OnModuleDestroy {
    * Initializes jobs
    */
   protected async initialize(): Promise<void> {
+    // The role switch, not a feature switch: a read-only API replica starts no updaters and
+    // with them none of the no-progress watchdogs that exit the process.
+    if (!this.configService.get('UPDATE_JOBS_ENABLE')) {
+      this.prometheusService.updateJobsEnabled.set(0);
+      this.logger.log('Update jobs are disabled: this instance serves the API only');
+      return;
+    }
+    this.prometheusService.updateJobsEnabled.set(1);
+
     await this.keysUpdateService.initialize();
     if (this.validatorUpdateService.isDisabledRegistry()) {
       this.prometheusService.validatorsEnabled.set(0);

--- a/src/jobs/keys-update/keys-update.service.ts
+++ b/src/jobs/keys-update/keys-update.service.ts
@@ -164,16 +164,42 @@ export class KeysUpdateService {
       process.exit(1);
     }
 
-    await this.entityManager.transactional(
-      async () => {
+    // The single-worker topology makes a second writer a deployment mistake (manual scale, a
+    // Terminating pod outliving its replacement) — this transaction stays correct anyway: the
+    // advisory lock serializes writers, and the re-read under it keeps a writer that fetched
+    // an older block from rolling the database backwards. READ_COMMITTED alone allows exactly
+    // that lost update.
+    const updated = await this.entityManager.transactional(
+      async (em) => {
+        const [{ locked }] = await em.execute<{ locked: boolean }[]>(
+          "select pg_try_advisory_xact_lock(hashtext('lido-keys-api:keys-update')) as locked",
+        );
+        if (!locked) {
+          this.logger.warn('Another instance is writing the keys update, skipping this cycle');
+          return false;
+        }
+
+        const metaNow = await this.elMetaStorage.get();
+        if (metaNow && metaNow.blockNumber > currElMeta.number) {
+          this.logger.warn('Another instance stored a newer block, skipping this cycle', { metaNow, currElMeta });
+          return false;
+        }
+        if (metaNow && metaNow.blockHash === currElMeta.hash) {
+          this.logger.log('Another instance stored the same block, updating is not required', { currElMeta });
+          return false;
+        }
+
         await this.stakingModuleUpdaterService.updateStakingModules({
           currElMeta,
-          prevElMeta,
+          prevElMeta: metaNow,
           contractModules,
         });
+        return true;
       },
       { isolationLevel: IsolationLevel.READ_COMMITTED },
     );
+
+    if (!updated) return;
 
     return currElMeta;
   }

--- a/src/jobs/keys-update/keys-update.service.ts
+++ b/src/jobs/keys-update/keys-update.service.ts
@@ -164,11 +164,8 @@ export class KeysUpdateService {
       process.exit(1);
     }
 
-    // The single-worker topology makes a second writer a deployment mistake (manual scale, a
-    // Terminating pod outliving its replacement) — this transaction stays correct anyway: the
-    // advisory lock serializes writers, and the re-read under it keeps a writer that fetched
-    // an older block from rolling the database backwards. READ_COMMITTED alone allows exactly
-    // that lost update.
+    // READ_COMMITTED alone allows a lost update — a writer holding an older block overwrites a newer one — so the
+    // meta is re-read under the lock and the cycle is skipped when it has already moved on.
     const updated = await this.entityManager.transactional(
       async (em) => {
         const [{ locked }] = await em.execute<{ locked: boolean }[]>(

--- a/src/jobs/keys-update/test/update-lock.spec.ts
+++ b/src/jobs/keys-update/test/update-lock.spec.ts
@@ -1,0 +1,92 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConfigService } from 'common/config';
+import { JobService } from 'common/job';
+import { PrometheusService } from 'common/prometheus';
+import { ExecutionProviderService } from 'common/execution-provider';
+import { StakingRouterService } from 'staking-router-modules/staking-router.service';
+import { StakingRouterFetchService } from 'staking-router-modules/contracts';
+import { ElMetaStorageService } from 'storage/el-meta.storage';
+import { SRModuleStorageService } from 'storage/sr-module.storage';
+import { EntityManager } from '@mikro-orm/knex';
+import { KeysUpdateService } from '../keys-update.service';
+import { StakingModuleUpdaterService } from '../staking-module-updater.service';
+
+describe('KeysUpdateService update: advisory lock and re-read under it', () => {
+  const currElMeta = { number: 200, hash: '0xcurr', timestamp: 2000 };
+  const prevElMeta = { blockNumber: 100, blockHash: '0xprev', timestamp: 1000 };
+
+  let keysUpdateService: KeysUpdateService;
+  let updateStakingModules: jest.Mock;
+  let elMetaGet: jest.Mock;
+  let execute: jest.Mock;
+
+  const build = async () => {
+    updateStakingModules = jest.fn();
+    execute = jest.fn().mockResolvedValue([{ locked: true }]);
+    elMetaGet = jest.fn().mockResolvedValue(prevElMeta);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: JobService, useValue: {} },
+        { provide: SchedulerRegistry, useValue: {} },
+        { provide: StakingRouterService, useValue: {} },
+        { provide: StakingRouterFetchService, useValue: { getStakingModules: jest.fn().mockResolvedValue([]) } },
+        { provide: ElMetaStorageService, useValue: { get: (...args) => elMetaGet(...args) } },
+        {
+          provide: EntityManager,
+          useValue: { transactional: (cb: (em: unknown) => Promise<unknown>) => cb({ execute }) },
+        },
+        { provide: ExecutionProviderService, useValue: { getBlock: jest.fn().mockResolvedValue(currElMeta) } },
+        { provide: SRModuleStorageService, useValue: { findAll: jest.fn().mockResolvedValue([]) } },
+        { provide: PrometheusService, useValue: {} },
+        { provide: StakingModuleUpdaterService, useValue: { updateStakingModules } },
+        KeysUpdateService,
+      ],
+    }).compile();
+
+    keysUpdateService = module.get(KeysUpdateService);
+  };
+
+  it('skips the cycle without writing when another instance holds the lock', async () => {
+    await build();
+    execute.mockResolvedValue([{ locked: false }]);
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('skips when the re-read under the lock sees a newer block', async () => {
+    await build();
+    elMetaGet
+      .mockResolvedValueOnce(prevElMeta)
+      .mockResolvedValueOnce({ blockNumber: 300, blockHash: '0xnewer', timestamp: 3000 });
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('skips when the re-read under the lock sees the same block already stored', async () => {
+    await build();
+    elMetaGet
+      .mockResolvedValueOnce(prevElMeta)
+      .mockResolvedValueOnce({ blockNumber: 200, blockHash: '0xcurr', timestamp: 2000 });
+
+    expect(await keysUpdateService.update()).toBeUndefined();
+    expect(updateStakingModules).not.toHaveBeenCalled();
+  });
+
+  it('writes against the meta read under the lock, not the one read before it', async () => {
+    await build();
+    const metaUnderLock = { blockNumber: 150, blockHash: '0xmid', timestamp: 1500 };
+    elMetaGet.mockResolvedValueOnce(prevElMeta).mockResolvedValueOnce(metaUnderLock);
+
+    expect(await keysUpdateService.update()).toEqual(currElMeta);
+    expect(updateStakingModules).toHaveBeenCalledWith(
+      expect.objectContaining({ currElMeta, prevElMeta: metaUnderLock }),
+    );
+  });
+});

--- a/src/jobs/validators-update/test/update-lock.spec.ts
+++ b/src/jobs/validators-update/test/update-lock.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LOGGER_PROVIDER } from '@lido-nestjs/logger';
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { ConfigService } from 'common/config';
+import { JobService } from 'common/job';
+import { PrometheusService } from 'common/prometheus';
+import { ValidatorsService } from 'validators';
+import { EntityManager } from '@mikro-orm/knex';
+import { ValidatorsUpdateService } from '../validators-update.service';
+
+describe('ValidatorsUpdateService update: advisory lock around the registry write', () => {
+  const meta = {
+    epoch: 10,
+    slot: 320,
+    slotStateRoot: '0xstate',
+    blockNumber: 200,
+    blockHash: '0xcurr',
+    timestamp: 2000,
+  };
+
+  let validatorsUpdateService: ValidatorsUpdateService;
+  let updateValidators: jest.Mock;
+  let execute: jest.Mock;
+
+  const build = async () => {
+    updateValidators = jest.fn().mockResolvedValue(meta);
+    execute = jest.fn().mockResolvedValue([{ locked: true }]);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        { provide: LOGGER_PROVIDER, useValue: { log: jest.fn(), warn: jest.fn(), error: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+        { provide: JobService, useValue: {} },
+        { provide: SchedulerRegistry, useValue: {} },
+        { provide: PrometheusService, useValue: {} },
+        { provide: ValidatorsService, useValue: { updateValidators: (...args) => updateValidators(...args) } },
+        {
+          provide: EntityManager,
+          useValue: { transactional: (cb: (em: unknown) => Promise<unknown>) => cb({ execute }) },
+        },
+        ValidatorsUpdateService,
+      ],
+    }).compile();
+
+    validatorsUpdateService = module.get(ValidatorsUpdateService);
+  };
+
+  it('skips the cycle without writing when another instance holds the lock', async () => {
+    await build();
+    execute.mockResolvedValue([{ locked: false }]);
+
+    expect(await validatorsUpdateService['updateValidatorsUnderLock']()).toBeNull();
+    expect(updateValidators).not.toHaveBeenCalled();
+  });
+
+  it('writes the finalized state when it takes the lock', async () => {
+    await build();
+
+    expect(await validatorsUpdateService['updateValidatorsUnderLock']()).toEqual(meta);
+    expect(updateValidators).toHaveBeenCalledWith('finalized');
+  });
+
+  it('takes a lock of its own, not the one the keys update takes', async () => {
+    await build();
+
+    await validatorsUpdateService['updateValidatorsUnderLock']();
+    expect(execute).toHaveBeenCalledWith(expect.stringContaining('lido-keys-api:validators-update'));
+  });
+});

--- a/src/jobs/validators-update/validators-update.service.ts
+++ b/src/jobs/validators-update/validators-update.service.ts
@@ -6,6 +6,9 @@ import { JobService } from 'common/job';
 import { ValidatorsService } from 'validators';
 import { OneAtTime } from 'common/decorators/oneAtTime';
 import { SchedulerRegistry } from '@nestjs/schedule';
+import { EntityManager } from '@mikro-orm/knex';
+import { IsolationLevel } from '@mikro-orm/core';
+import { ConsensusMeta } from '@lido-nestjs/validators-registry';
 
 export interface ValidatorsFilter {
   pubkeys: string[];
@@ -32,6 +35,7 @@ export class ValidatorsUpdateService {
     protected readonly jobService: JobService,
     protected readonly validatorsService: ValidatorsService,
     protected readonly schedulerRegistry: SchedulerRegistry,
+    protected readonly entityManager: EntityManager,
   ) {}
 
   // prometheus metrics
@@ -87,10 +91,35 @@ export class ValidatorsUpdateService {
     }, this.UPDATE_VALIDATORS_TIMEOUT_MS);
   }
 
+  // Same overlap as the keys update: the rollout starts the new pod before the old one is gone,
+  // so two writers coexist for a while. The registry's own transaction does not cover that — it
+  // reads the stored meta before opening it, and the write is delete-all plus re-insert, so a
+  // writer that fetched an older slot can throw away the newer validator set and put its own
+  // back. Under the lock that read happens inside this transaction: MikroORM carries the
+  // transaction context into the registry's entity manager, so its write nests here instead of
+  // taking a second connection, and its own `slot > previousMeta.slot` check becomes the re-read
+  // under the lock.
+  private async updateValidatorsUnderLock(): Promise<ConsensusMeta | null> {
+    return this.entityManager.transactional(
+      async (em) => {
+        const [{ locked }] = await em.execute<{ locked: boolean }[]>(
+          "select pg_try_advisory_xact_lock(hashtext('lido-keys-api:validators-update')) as locked",
+        );
+        if (!locked) {
+          this.logger.warn('Another instance is writing the validators update, skipping this cycle');
+          return null;
+        }
+
+        return this.validatorsService.updateValidators('finalized');
+      },
+      { isolationLevel: IsolationLevel.READ_COMMITTED },
+    );
+  }
+
   @OneAtTime()
   private async updateValidators() {
     await this.jobService.wrapJob({ name: 'Update validators from ValidatorsRegistry' }, async () => {
-      const meta = await this.validatorsService.updateValidators('finalized');
+      const meta = await this.updateValidatorsUnderLock();
       // meta shouldn't be null
       // if update didnt happen, meta will be fetched from db
       this.lastBlockTimestampSec = meta?.timestamp ?? this.lastBlockTimestampSec;

--- a/src/jobs/validators-update/validators-update.service.ts
+++ b/src/jobs/validators-update/validators-update.service.ts
@@ -91,14 +91,8 @@ export class ValidatorsUpdateService {
     }, this.UPDATE_VALIDATORS_TIMEOUT_MS);
   }
 
-  // Same overlap as the keys update: the rollout starts the new pod before the old one is gone,
-  // so two writers coexist for a while. The registry's own transaction does not cover that — it
-  // reads the stored meta before opening it, and the write is delete-all plus re-insert, so a
-  // writer that fetched an older slot can throw away the newer validator set and put its own
-  // back. Under the lock that read happens inside this transaction: MikroORM carries the
-  // transaction context into the registry's entity manager, so its write nests here instead of
-  // taking a second connection, and its own `slot > previousMeta.slot` check becomes the re-read
-  // under the lock.
+  // `updateStream` reads the stored meta outside its own write transaction, so an older-slot writer drops a newer set
+  // unless the lock covers that read: MikroORM carries this transaction into the registry's own entity manager.
   private async updateValidatorsUnderLock(): Promise<ConsensusMeta | null> {
     return this.entityManager.transactional(
       async (em) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,9 +38,8 @@ async function bootstrap() {
   const corsWhitelist = configService.get('CORS_WHITELIST_REGEXP');
   const sentryDsn = configService.get('SENTRY_DSN') ?? undefined;
 
-  // Several instances boot concurrently (API replicas and the worker) and each runs the
-  // migrator: on a fresh database two concurrent `create table` race into a pg_type unique
-  // violation. The lock serializes them; the losers find the migrations already applied.
+  // Concurrent `migrator.up()` on a fresh database races two `create table` into a pg_type unique violation; the
+  // losers of the lock find the migrations already applied.
   const orm = app.get(MikroORM);
   await orm.em.transactional(async (em) => {
     await (em as EntityManager).execute("select pg_advisory_xact_lock(hashtext('lido-keys-api:migrations'))");

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { SWAGGER_URL } from './http/common/swagger';
 import { ConfigService, VALIDATED_ENV } from './common/config';
 import { AppModule, APP_DESCRIPTION, APP_NAME, APP_VERSION } from './app';
 import { MikroORM } from '@mikro-orm/core';
+import { EntityManager } from '@mikro-orm/knex';
 import { PrometheusService } from './common/prometheus';
 import { SecretsWatcher, secretsFileMtimeMs } from './common/secrets';
 
@@ -37,8 +38,14 @@ async function bootstrap() {
   const corsWhitelist = configService.get('CORS_WHITELIST_REGEXP');
   const sentryDsn = configService.get('SENTRY_DSN') ?? undefined;
 
-  // migrating when starting application
-  await app.get(MikroORM).getMigrator().up();
+  // Several instances boot concurrently (API replicas and the worker) and each runs the
+  // migrator: on a fresh database two concurrent `create table` race into a pg_type unique
+  // violation. The lock serializes them; the losers find the migrations already applied.
+  const orm = app.get(MikroORM);
+  await orm.em.transactional(async (em) => {
+    await (em as EntityManager).execute("select pg_advisory_xact_lock(hashtext('lido-keys-api:migrations'))");
+    await orm.getMigrator().up();
+  });
 
   // versions
   app.enableVersioning({ type: VersioningType.URI });


### PR DESCRIPTION
KAPI as N read-only API replicas plus one updater instance. The role switch is parked deliberately: KAPI stays a singleton for now (the chart pins replicas=1 at render time), and it lands when a consumer actually needs a no-gap KAPI. The write locks are not part of that wait — a rolling update can have the replacement pod serving before the old one is gone, so two updaters coexist for a while even at a single replica.

- `UPDATE_JOBS_ENABLE` (default `true` — nothing changes for existing deployments): `false` starts no background updaters and none of their no-progress watchdogs, HTTP behavior untouched. The updaters then run in a single separate instance with the flag left on.
- The keys write cycle takes a Postgres advisory xact lock and re-reads the stored meta under it: two updaters serialize instead of racing, and a writer holding an older block cannot roll the database back. READ_COMMITTED alone allows exactly that lost update.
- The validators write takes a lock of its own, on a separate key. `updateStream` in `@lido-nestjs/validators-registry` reads the stored meta outside its own write transaction and then rewrites the set wholesale, so an updater holding an older slot could drop a newer one; under the lock that read happens inside our transaction, which turns the package's own slot check into the re-read. Its write nests as a savepoint on our connection instead of opening a second one — checked by comparing `pg_backend_pid()` across the outer, the nested and a rival transaction.
- Startup migrations take the same kind of lock: concurrent `migrator.up()` on a fresh database races into a pg_type unique violation — caught live, not hypothesized.

Verified on a local k3d cluster against live Hoodi, two API replicas plus a worker StatefulSet: fresh database (API pods wait NotReady until the first meta row, zero restarts), worker death (API keeps serving), two workers at once (lock skips, meta stays monotonic), API rolling restart under a request probe (no failed request).
