### PR TITLE
 Rate-limit by real client IP (behind Cloudflare)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "ethers": "^5.5.4",
+    "ip-address": "^10.4.0",
     "jsonstream": "^1.0.3",
     "pg-query-stream": "^4.5.3",
     "prom-client": "^14.2.0",

--- a/src/common/health/health.controller.ts
+++ b/src/common/health/health.controller.ts
@@ -1,11 +1,13 @@
 import { HealthCheckService, MemoryHealthIndicator, HealthCheck } from '@nestjs/terminus';
 import { Controller, Get } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 import { HEALTH_URL } from './health.constants';
 import { HEAP_USED_THRESHOLD } from './constants';
 
 @Controller(HEALTH_URL)
 @ApiExcludeController()
+@SkipThrottle()
 export class HealthController {
   constructor(protected health: HealthCheckService, protected memory: MemoryHealthIndicator) {}
 

--- a/src/common/prometheus/prometheus.controller.ts
+++ b/src/common/prometheus/prometheus.controller.ts
@@ -1,7 +1,9 @@
 import { PrometheusController as PrometheusControllerSource } from '@willsoto/nestjs-prometheus';
 import { Controller } from '@nestjs/common';
 import { ApiExcludeController } from '@nestjs/swagger';
+import { SkipThrottle } from '@nestjs/throttler';
 
 @Controller()
 @ApiExcludeController()
+@SkipThrottle()
 export class PrometheusController extends PrometheusControllerSource {}

--- a/src/http/common/throttler/throttler.guard.spec.ts
+++ b/src/http/common/throttler/throttler.guard.spec.ts
@@ -1,0 +1,119 @@
+import { ExecutionContext } from '@nestjs/common';
+import { ThrottlerException, ThrottlerStorageService } from '@nestjs/throttler';
+import type { FastifyRequest } from 'fastify';
+import { ThrottlerBehindProxyGuard } from './throttler.guard';
+
+const IPV6_PREFIX = '2001:db8:1234:5678';
+const TTL_MS = 60_000;
+const LIMIT = 5;
+
+const buildRequest = (ip: string): FastifyRequest =>
+  ({
+    ip,
+    ips: [ip],
+    headers: {},
+  } as unknown as FastifyRequest);
+
+const buildContext = (request: FastifyRequest): ExecutionContext => {
+  const response = { header: () => undefined };
+
+  return {
+    getClass: () => ({ name: 'RateLimitedController' }),
+    getHandler: () => ({ name: 'readStatus' }),
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  } as unknown as ExecutionContext;
+};
+
+describe('ThrottlerBehindProxyGuard', () => {
+  let guard: ThrottlerBehindProxyGuard;
+  let storage: ThrottlerStorageService;
+
+  // getTracker is protected; call it directly for unit-level assertions
+  const track = (ip: string): Promise<string> => (guard as any).getTracker(buildRequest(ip));
+
+  beforeEach(async () => {
+    storage = new ThrottlerStorageService();
+    guard = new ThrottlerBehindProxyGuard({ throttlers: [{ ttl: TTL_MS, limit: LIMIT }] } as any, storage, {
+      getAllAndOverride: () => undefined,
+    } as any);
+    await guard.onModuleInit();
+  });
+
+  afterEach(() => {
+    // the real storage service schedules an expiry timer for every accepted hit
+    storage.onApplicationShutdown();
+  });
+
+  describe('getTracker normalization', () => {
+    it('returns an IPv4 address unchanged', async () => {
+      await expect(track('10.0.0.1')).resolves.toBe('10.0.0.1');
+    });
+
+    it('aggregates two IPv6 addresses from the same /64 to the same tracker', async () => {
+      const a = await track(`${IPV6_PREFIX}::101`);
+      const b = await track(`${IPV6_PREFIX}::102`);
+      expect(a).toBe(`${IPV6_PREFIX}::/64`);
+      expect(b).toBe(a);
+    });
+
+    it('keeps IPv6 addresses from different /64 blocks in distinct trackers', async () => {
+      const a = await track(`${IPV6_PREFIX}::1`);
+      const b = await track('2001:db8:1234:9999::1');
+      expect(a).not.toBe(b);
+    });
+
+    it('unwraps IPv4-mapped IPv6 to plain IPv4', async () => {
+      await expect(track('::ffff:10.0.0.5')).resolves.toBe('10.0.0.5');
+      const mappedA = await track('::ffff:10.0.0.5');
+      const mappedB = await track('::ffff:10.0.0.6');
+      expect(mappedA).not.toBe(mappedB);
+    });
+
+    it('treats a non-mapped IPv6 written with a dotted-quad tail as IPv6 (/64), not IPv4', async () => {
+      // 2001:db8::1.2.3.4 is a real IPv6 address — the dotted-quad is just an
+      // alternate spelling of the last 32 bits (0102:0304), not an IPv4-mapped
+      // address (::ffff:0:0/96), so it is aggregated by /64.
+      await expect(track('2001:db8::1.2.3.4')).resolves.toBe('2001:db8::/64');
+    });
+
+    it('unwraps an IPv4-mapped IPv6 written in hex form to plain IPv4', async () => {
+      // ::ffff:0102:0304 is the hex spelling of ::ffff:1.2.3.4.
+      await expect(track('::ffff:0102:0304')).resolves.toBe('1.2.3.4');
+    });
+
+    it('falls back to the raw string for unparseable input', async () => {
+      await expect(track('not-an-ip')).resolves.toBe('not-an-ip');
+    });
+  });
+
+  describe('rate-limit bucketing', () => {
+    it('shares the /64 bucket across IPv6 addresses from the same block', async () => {
+      const requestA = buildRequest(`${IPV6_PREFIX}::101`);
+      const requestB = buildRequest(`${IPV6_PREFIX}::102`);
+
+      for (let i = 0; i < LIMIT; i += 1) {
+        await expect(guard.canActivate(buildContext(requestA))).resolves.toBe(true);
+      }
+      await expect(guard.canActivate(buildContext(requestA))).rejects.toBeInstanceOf(ThrottlerException);
+
+      // addrB shares the /64 bucket, so it is counted against the same limit
+      await expect(guard.canActivate(buildContext(requestB))).rejects.toBeInstanceOf(ThrottlerException);
+    });
+
+    it('keeps distinct IPv4 clients in independent buckets', async () => {
+      const requestA = buildRequest('10.0.0.1');
+      const requestB = buildRequest('10.0.0.2');
+
+      for (let i = 0; i < LIMIT; i += 1) {
+        await expect(guard.canActivate(buildContext(requestA))).resolves.toBe(true);
+      }
+      await expect(guard.canActivate(buildContext(requestA))).rejects.toBeInstanceOf(ThrottlerException);
+
+      // a different IPv4 address must not inherit A's exhausted bucket
+      await expect(guard.canActivate(buildContext(requestB))).resolves.toBe(true);
+    });
+  });
+});

--- a/src/http/common/throttler/throttler.guard.ts
+++ b/src/http/common/throttler/throttler.guard.ts
@@ -1,10 +1,44 @@
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { Injectable } from '@nestjs/common';
 import { FastifyRequest } from 'fastify';
+import { isIP } from 'net';
+import { Address6 } from 'ip-address';
 
 @Injectable()
 export class ThrottlerBehindProxyGuard extends ThrottlerGuard {
   protected async getTracker(request: FastifyRequest): Promise<string> {
-    return request.ips?.length ? request.ips[0] : request.ip;
+    return normalizeTracker(resolveClientIp(request));
+  }
+}
+
+// Behind Cloudflare the client IP comes from CF-Connecting-IP; otherwise fall
+// back to request.ip.
+function resolveClientIp(request: FastifyRequest): string {
+  const cfConnectingIp = request.headers['cf-connecting-ip'];
+
+  if (typeof cfConnectingIp === 'string') {
+    const ip = cfConnectingIp.trim();
+    if (isIP(ip)) return ip;
+  }
+
+  return request.ip;
+}
+
+// Per-client key: IPv4 as-is, IPv6 reduced to its /64 prefix.
+function normalizeTracker(ip: string): string {
+  if (isIP(ip) !== 6) return ip;
+
+  try {
+    const address = new Address6(ip);
+
+    // IPv4-mapped IPv6 (::ffff:a.b.c.d) -> the plain IPv4 address.
+    // isMapped4() matches only the ::ffff:0:0/96 form, unlike is4().
+    if (address.isMapped4()) {
+      return address.to4().correctForm();
+    }
+
+    return `${new Address6(`${ip}/64`).startAddress().correctForm()}/64`;
+  } catch {
+    return ip;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,8 @@ async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(
     AppModule,
     new FastifyAdapter({
-      trustProxy: true,
+      // request.ip is the raw socket peer; X-Forwarded-For is not trusted.
+      trustProxy: false,
       ignoreTrailingSlash: true,
     }),
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4322,6 +4322,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+ip-address@^10.4.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.7.0.tgz#9713429f16787ede8f642f6255b41fb515c825d9"
+  integrity sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==
+
 ipaddr.js@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"


### PR DESCRIPTION
 Problem
  The rate limiter counted every request under the proxy's IP, so all clients shared one bucket. The limit was effectively useless
  behind Cloudflare.

  Fix
  Use the real client IP as the rate-limit key:
  - Behind Cloudflare → read CF-Connecting-IP (Cloudflare sets it, clients can't forge it).
  - Otherwise → fall back to request.ip (the socket peer).
  - trustProxy: false — we no longer trust X-Forwarded-For.

  IPv6 handling
  - IPv6 is bucketed by its /64 prefix (one client usually owns a whole /64).
  - IPv4-mapped IPv6 (::ffff:1.2.3.4) is converted back to plain IPv4.

  Also
  - @SkipThrottle() on /health and /metrics — probes and scrapers must never be rate-limited.
  - Added ip-address dependency (IPv6 parsing). Run yarn install.

  Tests
  throttler.guard.spec.ts covers the IP normalization and bucketing.